### PR TITLE
Cache playback grants to avoid rate limiting

### DIFF
--- a/serverless/functions/token.js
+++ b/serverless/functions/token.js
@@ -144,6 +144,7 @@ module.exports.handler = async (context, event, callback) => {
           data: {
             playerStreamerSid: playerStreamer.data.sid,
             mediaProcessorSid: mediaProcessor.data.sid,
+            playbackGrant: null,
           },
         });
       } catch (e) {

--- a/serverless/middleware/common.private.js
+++ b/serverless/middleware/common.private.js
@@ -20,9 +20,12 @@ module.exports = (context, event, callback) => {
   async function getPlaybackGrant(playerStreamerSid) {
     const playbackGrant = await axiosClient(`PlayerStreamers/${playerStreamerSid}/PlaybackGrant`, {
       method: 'post',
-      data: `AccessControlAllowOrigin=*`,
+      data: `Ttl=60&AccessControlAllowOrigin=*`,
     });
-    return playbackGrant.data.grant;
+    return {
+      grant: playbackGrant.data.grant,
+      grantExpiration: new Date().getTime() + 45000
+    };
   }
 
   return {


### PR DESCRIPTION
With this change playback grants are requested with 60 seconds of TTL, and then reused over a period of 45 seconds. The end result is that playback grants are requested no sooner than 45 seconds apart, regardless of attendee traffic.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
