### PR TITLE
Improve raised hand UX

### DIFF
--- a/apps/ios/LiveVideo/LiveVideo/Assets.xcassets/Colors/BackgroundHighlight.colorset/Contents.json
+++ b/apps/ios/LiveVideo/LiveVideo/Assets.xcassets/Colors/BackgroundHighlight.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.549",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/apps/ios/LiveVideo/LiveVideo/Views/Stream/StreamToolbarButton.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Views/Stream/StreamToolbarButton.swift
@@ -13,6 +13,10 @@ struct StreamToolbarButton: View {
             imageForegroundColor: .backgroundStrongest,
             imageBackgroundColor: .backgroundStrong
         )
+        static let highlight = Role(
+            imageForegroundColor: .white,
+            imageBackgroundColor: .backgroundHighlight
+        )
         static let destructive = Role(
             imageForegroundColor: .white,
             imageBackgroundColor: .backgroundDestructive
@@ -24,7 +28,12 @@ struct StreamToolbarButton: View {
     let shouldShowBadge: Bool
     let action: () -> Void
     
-    init(image: Image, role: Role = .default, shouldShowBadge: Bool = false, action: @escaping () -> Void = { }) {
+    init(
+        image: Image,
+        role: Role = .default,
+        shouldShowBadge: Bool = false,
+        action: @escaping () -> Void = { }
+    ) {
         self.image = image
         self.role = role
         self.shouldShowBadge = shouldShowBadge
@@ -78,6 +87,8 @@ struct StreamToolbarButton_Previews: PreviewProvider {
         Group {
             StreamToolbarButton(image: Image(systemName: "mic.slash"))
                 .previewDisplayName("Default")
+            StreamToolbarButton(image: Image(systemName: "hand.raised"), role: .highlight)
+                .previewDisplayName("Highlight")
             StreamToolbarButton(image: Image(systemName: "person.2"), shouldShowBadge: true)
                 .previewDisplayName("Badge")
             StreamToolbarButton(image: Image(systemName: "arrow.left"), role: .destructive)

--- a/apps/ios/LiveVideo/LiveVideo/Views/Stream/StreamView.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Views/Stream/StreamView.swift
@@ -60,20 +60,17 @@ struct StreamView: View {
                         switch streamManager.config.role {
                         case .host, .speaker:
                             StreamToolbarButton(
-                                image: Image(systemName: speakerSettingsManager.isMicOn ? "mic" : "mic.slash"),
-                                role: .default
+                                image: Image(systemName: speakerSettingsManager.isMicOn ? "mic" : "mic.slash")
                             ) {
                                 speakerSettingsManager.isMicOn.toggle()
                             }
                             StreamToolbarButton(
-                                image: Image(systemName: speakerSettingsManager.isCameraOn ? "video" : "video.slash"),
-                                role: .default
+                                image: Image(systemName: speakerSettingsManager.isCameraOn ? "video" : "video.slash")
                             ) {
                                 speakerSettingsManager.isCameraOn.toggle()
                             }
                             StreamToolbarButton(
                                 image: Image(systemName: "person.2"),
-                                role: .default,
                                 shouldShowBadge: raisedHandsStore.haveNew
                             ) {
                                 isShowingParticipants = true
@@ -86,8 +83,7 @@ struct StreamView: View {
                                     }
                                 } label: {
                                     StreamToolbarButton(
-                                        image: Image(systemName: "ellipsis"),
-                                        role: .default
+                                        image: Image(systemName: "ellipsis")
                                     ) {
 
                                     }
@@ -95,8 +91,8 @@ struct StreamView: View {
                             }
                         case .viewer:
                             StreamToolbarButton(
-                                image: Image(systemName: viewModel.isHandRaised ? "hand.raised" : "hand.raised.slash"),
-                                role: .default
+                                image: Image(systemName: "hand.raised"),
+                                role: viewModel.isHandRaised ? .highlight : .default
                             ) {
                                 viewModel.isHandRaised.toggle()
                             }

--- a/apps/ios/LiveVideo/LiveVideo/Views/Style/Color.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Views/Style/Color.swift
@@ -9,6 +9,7 @@ extension Color {
     static var background: Color { Color("Background") }
     static var backgroundBrandStronger: Color { Color("BackgroundBrandStronger") }
     static var backgroundDestructive: Color { Color("BackgroundDestructive") }
+    static var backgroundHighlight: Color { Color("BackgroundHighlight") }
     static var backgroundLiveBadge: Color { Color("BackgroundLiveBadge") }
     static var backgroundPrimary: Color { Color("BackgroundPrimary") }
     static var backgroundPrimaryWeak: Color { Color("BackgroundPrimaryWeak") }


### PR DESCRIPTION
I made this change as low risk as possible. I think I may want to refactor `StreamToolbarButton` later. `highlight` doesn't really fit with `default` and `destructive` as a role. It is kind of confusing purpose with state.

1. Use blue background when hand is raised and gray background when hand is not raised.
2. Also removed unnecessary optional parameter in a few places.

![Simulator Screen Shot - iPhone 13 - 2021-10-19 at 17 17 43](https://user-images.githubusercontent.com/1930363/138003828-0730d4f9-6ace-42f8-bca9-ceacac586efe.png)
![Simulator Screen Shot - iPhone 13 - 2021-10-19 at 17 17 36](https://user-images.githubusercontent.com/1930363/138003830-81e86c78-5ce0-4e58-aae2-d5818689c8a8.png)