### PR TITLE
VIDEO-7631: Use one sync service per stream

### DIFF
--- a/serverless/constants.js
+++ b/serverless/constants.js
@@ -1,7 +1,10 @@
+const syncServicePrefix = 'Live Video '
+
 module.exports = {
   MEDIA_EXTENSION: 'video-composer-v1',
   SERVICE_NAME: 'twilio-live-interactive-video',
   API_KEY_NAME: 'Twilio Live Interactive Video API Key',
   TWILIO_CONVERSATIONS_SERVICE_NAME: 'Twilio Live Interactive Video Conversations Service',
-  TWILIO_SYNC_SERVICE_NAME: 'Twilio Live Interactive Video Sync Service',
+  SYNC_SERVICE_NAME_PREFIX: syncServicePrefix,
+  BACKEND_STORAGE_SYNC_SERVICE_NAME: syncServicePrefix + 'Backend Storage',
 };

--- a/serverless/functions/join-stream-as-speaker.js
+++ b/serverless/functions/join-stream-as-speaker.js
@@ -8,7 +8,7 @@ const SyncGrant = AccessToken.SyncGrant;
 const MAX_ALLOWED_SESSION_DURATION = 14400;
 
 module.exports.handler = async (context, event, callback) => {
-  const { ACCOUNT_SID, TWILIO_API_KEY_SID, TWILIO_API_KEY_SECRET, CONVERSATIONS_SERVICE_SID, SYNC_SERVICE_SID } =
+  const { ACCOUNT_SID, TWILIO_API_KEY_SID, TWILIO_API_KEY_SECRET, CONVERSATIONS_SERVICE_SID } =
     context;
 
   const { user_identity, stream_name } = event;
@@ -38,10 +38,9 @@ module.exports.handler = async (context, event, callback) => {
     return callback(null, response);
   }
 
-  let room, conversation;
+  let room, conversation, streamMapItem;
 
   const client = context.getTwilioClient();
-  const syncClient = client.sync.services(context.SYNC_SERVICE_SID);
 
   try {
     // See if a room already exists
@@ -57,9 +56,26 @@ module.exports.handler = async (context, event, callback) => {
     return callback(null, response);
   }
 
+  // Fetch stream map item
+  try {
+    const backendStorageSyncClient = await client.sync.services(context.BACKEND_STORAGE_SYNC_SERVICE_SID);
+    streamMapItem = await backendStorageSyncClient.syncMaps('streams').syncMapItems(room.sid).fetch();
+  } catch (e) {
+    response.setStatusCode(500);
+    response.setBody({
+      error: {
+        message: 'error finding stream map item',
+        explanation: e.message,
+      },
+    });
+    return callback(null, response);
+  }
+
+  const streamSyncClient = client.sync.services(streamMapItem.data.sync_service_sid);
+  
   try {
     // Reset the viewers hand_raised and speaker_invite status
-    await syncClient.documents(`viewer-${room.sid}-${user_identity}`).update({ data: { speaker_invite: false } });
+    await streamSyncClient.documents(`viewer-${user_identity}`).update({ data: { speaker_invite: false } });
   } catch (e) {
     // Ignore 404 errors. It is possible that the user may not have a viewer document
     if (e.code !== 20404) {
@@ -75,10 +91,10 @@ module.exports.handler = async (context, event, callback) => {
     }
   }
 
-  const raisedHandsMapName = `raised_hands-${room.sid}`;
+  const raisedHandsMapName = `raised_hands`;
   // Give user read access to raised hands map
   try {
-    await syncClient.syncMaps(raisedHandsMapName)
+    await streamSyncClient.syncMaps(raisedHandsMapName)
       .syncMapPermissions(user_identity)
       .update({ read: true, write: false, manage: false })
   } catch (e) {
@@ -94,7 +110,7 @@ module.exports.handler = async (context, event, callback) => {
 
   // Lower the participant's hand
   try {
-    await syncClient.syncMaps(raisedHandsMapName).syncMapItems(user_identity).remove();
+    await streamSyncClient.syncMaps(raisedHandsMapName).syncMapItems(user_identity).remove();
   } catch (e) {
     // Ignore 404 errors. It is possible that the user may not have a key in the raised hands map
     if (e.code !== 20404) {
@@ -162,7 +178,7 @@ module.exports.handler = async (context, event, callback) => {
   token.addGrant(chatGrant);
 
   // Add sync grant to token
-  const syncGrant = new SyncGrant({ serviceSid: SYNC_SERVICE_SID });
+  const syncGrant = new SyncGrant({ serviceSid: streamMapItem.data.sync_service_sid });
   token.addGrant(syncGrant);
 
   // Return token
@@ -170,7 +186,7 @@ module.exports.handler = async (context, event, callback) => {
   response.setBody({
     token: token.toJwt(),
     sync_object_names: {
-      raised_hands_map: `raised_hands-${room.sid}`,
+      raised_hands_map: `raised_hands`,
     },
   });
   return callback(null, response);

--- a/serverless/functions/join-stream-as-speaker.js
+++ b/serverless/functions/join-stream-as-speaker.js
@@ -13,6 +13,9 @@ module.exports.handler = async (context, event, callback) => {
 
   const { user_identity, stream_name } = event;
 
+  const common = require(Runtime.getAssets()['/common.js'].path);
+  const { getStreamMapItem } = common(context, event, callback);
+
   let response = new Twilio.Response();
   response.appendHeader('Content-Type', 'application/json');
 
@@ -58,8 +61,7 @@ module.exports.handler = async (context, event, callback) => {
 
   // Fetch stream map item
   try {
-    const backendStorageSyncClient = await client.sync.services(context.BACKEND_STORAGE_SYNC_SERVICE_SID);
-    streamMapItem = await backendStorageSyncClient.syncMaps('streams').syncMapItems(room.sid).fetch();
+    streamMapItem = await getStreamMapItem(room.sid);
   } catch (e) {
     response.setStatusCode(500);
     response.setBody({

--- a/serverless/functions/join-stream-as-viewer.js
+++ b/serverless/functions/join-stream-as-viewer.js
@@ -37,10 +37,9 @@ module.exports.handler = async (context, event, callback) => {
     return callback(null, response);
   }
 
-  let room, streamDocument, viewerDocument;
+  let room, streamMapItem, viewerDocument;
 
   const client = context.getTwilioClient();
-  const syncClient = client.sync.services(context.SYNC_SERVICE_SID);
 
   try {
     // See if a room already exists
@@ -57,10 +56,27 @@ module.exports.handler = async (context, event, callback) => {
     return callback(null, response);
   }
 
-  const viewerDocumentName = `viewer-${room.sid}-${user_identity}`;
+  // Fetch stream map item
+  try {
+    const backendStorageSyncClient = await client.sync.services(context.BACKEND_STORAGE_SYNC_SERVICE_SID);
+    streamMapItem = await backendStorageSyncClient.syncMaps('streams').syncMapItems(room.sid).fetch();
+  } catch (e) {
+    response.setStatusCode(500);
+    response.setBody({
+      error: {
+        message: 'error fetching stream map item',
+        explanation: e.message,
+      },
+    });
+    return callback(null, response);
+  }
+
+  const streamSyncClient = client.sync.services(streamMapItem.data.sync_service_sid);
+
+  const viewerDocumentName = `viewer-${user_identity}`;
   // Create viewer document
   try {
-    viewerDocument = await syncClient.documents.create({
+    viewerDocument = await streamSyncClient.documents.create({
       uniqueName: viewerDocumentName,
     });
   } catch (e) {
@@ -82,7 +98,7 @@ module.exports.handler = async (context, event, callback) => {
   // This is done outside of the viewer document creation to account
   // for viewers that may already have a viewer document
   try {
-    await syncClient.documents(viewerDocumentName).update({
+    await streamSyncClient.documents(viewerDocumentName).update({
       data: { speaker_invite: false },
     });
   } catch (e) {
@@ -99,7 +115,7 @@ module.exports.handler = async (context, event, callback) => {
 
   // Give user read access to viewer document
   try {
-    await syncClient.documents(viewerDocumentName)
+    await streamSyncClient.documents(viewerDocumentName)
       .documentPermissions(user_identity)
       .update({ read: true, write: false, manage: false })
   } catch (e) {
@@ -115,7 +131,7 @@ module.exports.handler = async (context, event, callback) => {
 
   // Give user read access to raised hands map
   try {
-    await syncClient.syncMaps(`raised_hands-${room.sid}`)
+    await streamSyncClient.syncMaps(`raised_hands`)
       .syncMapPermissions(user_identity)
       .update({ read: true, write: false, manage: false })
   } catch (e) {
@@ -129,23 +145,9 @@ module.exports.handler = async (context, event, callback) => {
     return callback(null, response);
   }
 
-  try {
-    // Get playerStreamerSid from stream document
-    streamDocument = await syncClient.documents(`stream-${room.sid}`).fetch();
-  } catch (e) {
-    response.setStatusCode(500);
-    response.setBody({
-      error: {
-        message: 'error finding stream document',
-        explanation: e.message,
-      },
-    });
-    return callback(null, response);
-  }
-
   let playbackGrant;
   try {
-    playbackGrant = await getPlaybackGrant(streamDocument.data.player_streamer_sid);
+    playbackGrant = await getPlaybackGrant(streamMapItem.data.player_streamer_sid);
   } catch (e) {
     console.error(e);
     response.setStatusCode(500);
@@ -178,7 +180,7 @@ module.exports.handler = async (context, event, callback) => {
   });
 
   // Add sync grant to token
-  const syncGrant = new SyncGrant({ serviceSid: context.SYNC_SERVICE_SID });
+  const syncGrant = new SyncGrant({ serviceSid: streamMapItem.data.sync_service_sid });
   token.addGrant(syncGrant);
 
   // Return token
@@ -186,8 +188,8 @@ module.exports.handler = async (context, event, callback) => {
   response.setBody({
     token: token.toJwt(),
     sync_object_names: {
-      raised_hands_map: `raised_hands-${room.sid}`,
-      viewer_document: `viewer-${room.sid}-${user_identity}`,
+      raised_hands_map: `raised_hands`,
+      viewer_document: `viewer-${user_identity}`,
     },
     room_sid: room.sid,
   });

--- a/serverless/functions/join-stream-as-viewer.js
+++ b/serverless/functions/join-stream-as-viewer.js
@@ -8,7 +8,7 @@ const MAX_ALLOWED_SESSION_DURATION = 14400;
 
 module.exports.handler = async (context, event, callback) => {
   const common = require(Runtime.getAssets()['/common.js'].path);
-  const { getPlaybackGrant } = common(context, event, callback);
+  const { getPlaybackGrant, getStreamMapItem } = common(context, event, callback);
 
   const { user_identity, stream_name } = event;
 
@@ -58,8 +58,7 @@ module.exports.handler = async (context, event, callback) => {
 
   // Fetch stream map item
   try {
-    const backendStorageSyncClient = await client.sync.services(context.BACKEND_STORAGE_SYNC_SERVICE_SID);
-    streamMapItem = await backendStorageSyncClient.syncMaps('streams').syncMapItems(room.sid).fetch();
+    streamMapItem = await getStreamMapItem(room.sid);
   } catch (e) {
     response.setStatusCode(500);
     response.setBody({

--- a/serverless/functions/raise-hand.js
+++ b/serverless/functions/raise-hand.js
@@ -4,6 +4,9 @@
 module.exports.handler = async (context, event, callback) => {
   const { user_identity, stream_name, hand_raised } = event;
 
+  const common = require(Runtime.getAssets()['/common.js'].path);
+  const { getStreamMapItem } = common(context, event, callback);
+
   if (!user_identity) {
     response.setStatusCode(400);
     response.setBody({
@@ -61,8 +64,7 @@ module.exports.handler = async (context, event, callback) => {
 
   // Get stream sync client
   try {
-    let backendStorageSyncClient = await client.sync.services(context.BACKEND_STORAGE_SYNC_SERVICE_SID);
-    let streamMapItem = await backendStorageSyncClient.syncMaps('streams').syncMapItems(room.sid).fetch();
+    let streamMapItem = await getStreamMapItem(room.sid);
     streamSyncClient = client.sync.services(streamMapItem.data.sync_service_sid);
   } catch (e) {
     response.setStatusCode(500);

--- a/serverless/functions/raise-hand.js
+++ b/serverless/functions/raise-hand.js
@@ -41,9 +41,8 @@ module.exports.handler = async (context, event, callback) => {
   response.appendHeader('Content-Type', 'application/json');
 
   const client = context.getTwilioClient();
-  const syncClient = client.sync.services(context.SYNC_SERVICE_SID);
 
-  let room;
+  let room, streamSyncClient;
 
   try {
     // See if a room already exists
@@ -60,12 +59,29 @@ module.exports.handler = async (context, event, callback) => {
     return callback(null, response);
   }
 
-  const raisedHandsMapName = `raised_hands-${room.sid}`;
+  // Get stream sync client
+  try {
+    let backendStorageSyncClient = await client.sync.services(context.BACKEND_STORAGE_SYNC_SERVICE_SID);
+    let streamMapItem = await backendStorageSyncClient.syncMaps('streams').syncMapItems(room.sid).fetch();
+    streamSyncClient = client.sync.services(streamMapItem.data.sync_service_sid);
+  } catch (e) {
+    response.setStatusCode(500);
+    response.setBody({
+      error: {
+        message: 'error getting stream sync client',
+        explanation: e.message,
+      },
+    });
+    return callback(null, response);
+  }
+
+  const raisedHandsMapName = `raised_hands`;
+
   try {
     if (hand_raised) {
-      await syncClient.syncMaps(raisedHandsMapName).syncMapItems.create({ key: user_identity, data: {} });
+      await streamSyncClient.syncMaps(raisedHandsMapName).syncMapItems.create({ key: user_identity, data: { } });
     } else {
-      await syncClient.syncMaps(raisedHandsMapName).syncMapItems(user_identity).remove();
+      await streamSyncClient.syncMaps(raisedHandsMapName).syncMapItems(user_identity).remove();
     }
   } catch (e) {
     // Ignore errors relating to removing a syncMapItem that doesn't exist (20404), or creating one that already does exist (54208)

--- a/serverless/functions/send-speaker-invite.js
+++ b/serverless/functions/send-speaker-invite.js
@@ -4,6 +4,9 @@
 module.exports.handler = async (context, event, callback) => {
   const { user_identity, room_sid } = event;
 
+  const common = require(Runtime.getAssets()['/common.js'].path);
+  const { getStreamMapItem } = common(context, event, callback);
+
   let response = new Twilio.Response();
   response.appendHeader('Content-Type', 'application/json');
 
@@ -11,8 +14,7 @@ module.exports.handler = async (context, event, callback) => {
 
   try {
     // Set speaker_invite to true
-    const backendStorageSyncClient = await client.sync.services(context.BACKEND_STORAGE_SYNC_SERVICE_SID);
-    const streamMapItem = await backendStorageSyncClient.syncMaps('streams').syncMapItems(room_sid).fetch();
+    const streamMapItem = await getStreamMapItem(room_sid);
     const streamSyncClient = await client.sync.services(streamMapItem.data.sync_service_sid);
     const doc = await streamSyncClient.documents(`viewer-${user_identity}`).fetch();
     await streamSyncClient.documents(doc.sid).update({ data: { ...doc.data, speaker_invite: true } });

--- a/serverless/functions/send-speaker-invite.js
+++ b/serverless/functions/send-speaker-invite.js
@@ -8,12 +8,14 @@ module.exports.handler = async (context, event, callback) => {
   response.appendHeader('Content-Type', 'application/json');
 
   const client = context.getTwilioClient();
-  const syncClient = client.sync.services(context.SYNC_SERVICE_SID);
 
   try {
     // Set speaker_invite to true
-    const doc = await syncClient.documents(`viewer-${room_sid}-${user_identity}`).fetch();
-    await syncClient.documents(doc.sid).update({ data: { ...doc.data, speaker_invite: true } });
+    const backendStorageSyncClient = await client.sync.services(context.BACKEND_STORAGE_SYNC_SERVICE_SID);
+    const streamMapItem = await backendStorageSyncClient.syncMaps('streams').syncMapItems(room_sid).fetch();
+    const streamSyncClient = await client.sync.services(streamMapItem.data.sync_service_sid);
+    const doc = await streamSyncClient.documents(`viewer-${user_identity}`).fetch();
+    await streamSyncClient.documents(doc.sid).update({ data: { ...doc.data, speaker_invite: true } });
   } catch (e) {
     console.error(e);
     response.setStatusCode(500);

--- a/serverless/middleware/common.private.js
+++ b/serverless/middleware/common.private.js
@@ -6,7 +6,8 @@ module.exports = (context, event, callback) => {
   let response = new Twilio.Response();
   response.appendHeader('Content-Type', 'application/json');
 
-  const { region } = context.getTwilioClient();
+  const client = context.getTwilioClient();
+  const region = client.region;  
 
   const axiosClient = axios.create({
     headers: {
@@ -25,9 +26,16 @@ module.exports = (context, event, callback) => {
     return playbackGrant.data.grant;
   }
 
+  async function getStreamMapItem(roomSid) {
+    const backendStorageSyncClient = await client.sync.services(context.BACKEND_STORAGE_SYNC_SERVICE_SID);
+    const mapItem = await backendStorageSyncClient.syncMaps('streams').syncMapItems(roomSid).fetch();
+    return mapItem;
+  }
+
   return {
     axiosClient,
     response,
     getPlaybackGrant,
+    getStreamMapItem
   };
 };

--- a/serverless/scripts/deploy.js
+++ b/serverless/scripts/deploy.js
@@ -32,7 +32,7 @@ async function findExistingConfiguration() {
     const envVariables = await serverlessClient.getEnvironmentVariables({
       serviceSid: service.sid,
       environment: 'dev',
-      keys: ['TWILIO_API_KEY_SID', 'TWILIO_API_KEY_SECRET', 'CONVERSATIONS_SERVICE_SID', 'SYNC_SERVICE_SID'],
+      keys: ['TWILIO_API_KEY_SID', 'TWILIO_API_KEY_SECRET', 'CONVERSATIONS_SERVICE_SID', 'BACKEND_STORAGE_SYNC_SERVICE_SID'],
       getValues: true,
     });
 
@@ -49,7 +49,7 @@ async function findExistingConfiguration() {
 }
 
 async function deployFunctions() {
-  let apiKey, conversationsService, syncService;
+  let apiKey, conversationsService, backendStorageSyncService, backendStorageSyncClient;
   const existingConfiguration = await findExistingConfiguration();
 
   if (!options.override && existingConfiguration) {
@@ -69,8 +69,10 @@ async function deployFunctions() {
       friendlyName: constants.TWILIO_CONVERSATIONS_SERVICE_NAME,
     });
 
-    cli.action.start('Creating Sync Service');
-    syncService = await client.sync.services.create({ friendlyName: constants.TWILIO_SYNC_SERVICE_NAME, aclEnabled: true });
+    cli.action.start('Creating Backend Storage Sync Service');
+    backendStorageSyncService = await client.sync.services.create({ friendlyName: constants.BACKEND_STORAGE_SYNC_SERVICE_NAME, aclEnabled: true });
+    backendStorageSyncClient = await client.sync.services(backendStorageSyncService.sid); 
+    await backendStorageSyncClient.syncMaps.create({ uniqueName: 'streams' });
   }
 
   const { assets, functions } = await getListOfFunctionsAndAssets(__dirname, {
@@ -106,7 +108,8 @@ async function deployFunctions() {
       TWILIO_API_KEY_SID: existingConfiguration?.TWILIO_API_KEY_SID || apiKey.sid,
       TWILIO_API_KEY_SECRET: existingConfiguration?.TWILIO_API_KEY_SECRET || apiKey.secret,
       CONVERSATIONS_SERVICE_SID: existingConfiguration?.CONVERSATIONS_SERVICE_SID || conversationsService.sid,
-      SYNC_SERVICE_SID: existingConfiguration?.SYNC_SERVICE_SID || syncService.sid,
+      BACKEND_STORAGE_SYNC_SERVICE_SID: existingConfiguration?.BACKEND_STORAGE_SYNC_SERVICE_SID || backendStorageSyncService.sid,
+      SYNC_SERVICE_NAME_PREFIX: constants.SYNC_SERVICE_NAME_PREFIX,
       MEDIA_EXTENSION: constants.MEDIA_EXTENSION,
       APP_EXPIRY: Date.now() + 1000 * 60 * 60 * 24 * 7, // One week
       PASSCODE: getRandomInt(6),

--- a/serverless/scripts/remove.js
+++ b/serverless/scripts/remove.js
@@ -27,12 +27,13 @@ async function remove() {
     client.conversations.services(conversationsService.sid).remove();
   }
 
-  cli.action.start('Removing Sync Service');
+  cli.action.start('Removing Sync Services');
   const syncServices = await client.sync.services.list();
-  const syncService = syncServices.find((key) => key.friendlyName === constants.TWILIO_SYNC_SERVICE_NAME);
-  if (syncService) {
-    client.sync.services(syncService.sid).remove();
-  }
+  syncServices.forEach(function(service) {
+    if (service.friendlyName.includes(constants.SYNC_SERVICE_NAME_PREFIX)) {
+      client.sync.services(service.sid).remove();
+    }
+  })
 
   cli.action.stop();
 }


### PR DESCRIPTION
## Pull Request Details

### JIRA link(s):

- [VIDEO-7631](https://issues.corp.twilio.com/browse/VIDEO-7631)

### Description

1. Create a `Live Video Backend Storage` sync service during deploy to store state that is only used by the backend. It has a `streams` map with room SID for key and a few other SIDs are stored in the map item data. Eventually the sync webhook may need to know room SID and I think there are some ways we could do that.
2. Create a sync service for each stream when the stream is created. This prepares us to use sync reachability which is scoped to a sync service. And it simplifies sync object names because we don't have to include room SID anymore.
3. No client changes were required so both web and iOS apps work.

## Burndown

### Before review
* [ ] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with all effected platforms
* [x] Manually sanity tested running locally
* [x] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary