### PR TITLE
VIDEO-7751: iOS Fix player view flicker

### DIFF
--- a/apps/ios/LiveVideo/LiveVideo/Views/Stream/SwiftUIPlayerView.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Views/Stream/SwiftUIPlayerView.swift
@@ -13,6 +13,11 @@ struct SwiftUIPlayerView: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: PlayerView, context: Context) {
+        guard player?.playerView !== uiView else {
+            /// If `playerView` is already set don't set it again. This prevents the view from filckering sometimes.
+            return
+        }
+        
         player?.playerView = uiView
     }
 }

--- a/apps/ios/LiveVideo/LiveVideo/Views/Stream/SwiftUIPlayerView.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Views/Stream/SwiftUIPlayerView.swift
@@ -14,7 +14,7 @@ struct SwiftUIPlayerView: UIViewRepresentable {
 
     func updateUIView(_ uiView: PlayerView, context: Context) {
         guard player?.playerView !== uiView else {
-            /// If `playerView` is already set don't set it again. This prevents the view from filckering sometimes.
+            /// If `playerView` is already set don't set it again. This prevents the view from flickering sometimes.
             return
         }
         


### PR DESCRIPTION
## Pull Request Details

### JIRA link(s):

- [VIDEO-7751](https://issues.corp.twilio.com/browse/VIDEO-7751)

### Description

The player view sometimes flickers. I can cause it to happen sometimes when tapping the raise hand button. SwiftUI seems to think that the view needs to be updated and the view sometimes flickers when assigning to the player.

For now I will fix in the app but I think we may be able to fix this in the SDK later. I think this issue could happen with UIKit and not just SwiftUI.

## Burndown

### Before review
* [ ] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with all effected platforms
* [x] Manually sanity tested running locally
* [x] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary


This is what the problem looks like:

https://user-images.githubusercontent.com/1930363/141379718-347d0d9c-2cd9-47ca-9bf9-c62d044a2b1e.mov