### PR TITLE
VIDEO-7752: Rename viewer document

### DIFF
--- a/apps/ios/LiveVideo/LiveVideo.xcodeproj/project.pbxproj
+++ b/apps/ios/LiveVideo/LiveVideo.xcodeproj/project.pbxproj
@@ -9,11 +9,11 @@
 /* Begin PBXBuildFile section */
 		DC175F2D270E232F00D9D1FE /* SyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC175F2C270E232F00D9D1FE /* SyncManager.swift */; };
 		DC175F30270E238F00D9D1FE /* TwilioSyncClient in Frameworks */ = {isa = PBXBuildFile; productRef = DC175F2F270E238F00D9D1FE /* TwilioSyncClient */; };
-		DC175F32270E23F900D9D1FE /* ViewerStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC175F31270E23F900D9D1FE /* ViewerStore.swift */; };
-		DC175F34270E3FD200D9D1FE /* SyncUsersStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC175F33270E3FD200D9D1FE /* SyncUsersStore.swift */; };
+		DC175F32270E23F900D9D1FE /* SyncUserDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC175F31270E23F900D9D1FE /* SyncUserDocument.swift */; };
+		DC175F34270E3FD200D9D1FE /* SyncUsersMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC175F33270E3FD200D9D1FE /* SyncUsersMap.swift */; };
 		DC175F37270E5B6F00D9D1FE /* ParticipantsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC175F36270E5B6F00D9D1FE /* ParticipantsView.swift */; };
 		DC175F39270F673600D9D1FE /* SendSpeakerInviteRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC175F38270F673600D9D1FE /* SendSpeakerInviteRequest.swift */; };
-		DC175F3E2717530D00D9D1FE /* SyncStoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC175F3D2717530D00D9D1FE /* SyncStoring.swift */; };
+		DC175F3E2717530D00D9D1FE /* SyncObjectConnecting.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC175F3D2717530D00D9D1FE /* SyncObjectConnecting.swift */; };
 		DC175F402718852B00D9D1FE /* DeleteStreamRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC175F3F2718852A00D9D1FE /* DeleteStreamRequest.swift */; };
 		DC1ED0F026DFCD3C00FFA769 /* LiveBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1ED0EF26DFCD3C00FFA769 /* LiveBadge.swift */; };
 		DC1ED0F726E12C7400FFA769 /* ProgressHUD.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1ED0F626E12C7400FFA769 /* ProgressHUD.swift */; };
@@ -102,11 +102,11 @@
 
 /* Begin PBXFileReference section */
 		DC175F2C270E232F00D9D1FE /* SyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncManager.swift; sourceTree = "<group>"; };
-		DC175F31270E23F900D9D1FE /* ViewerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewerStore.swift; sourceTree = "<group>"; };
-		DC175F33270E3FD200D9D1FE /* SyncUsersStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncUsersStore.swift; sourceTree = "<group>"; };
+		DC175F31270E23F900D9D1FE /* SyncUserDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncUserDocument.swift; sourceTree = "<group>"; };
+		DC175F33270E3FD200D9D1FE /* SyncUsersMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncUsersMap.swift; sourceTree = "<group>"; };
 		DC175F36270E5B6F00D9D1FE /* ParticipantsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantsView.swift; sourceTree = "<group>"; };
 		DC175F38270F673600D9D1FE /* SendSpeakerInviteRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendSpeakerInviteRequest.swift; sourceTree = "<group>"; };
-		DC175F3D2717530D00D9D1FE /* SyncStoring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncStoring.swift; sourceTree = "<group>"; };
+		DC175F3D2717530D00D9D1FE /* SyncObjectConnecting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncObjectConnecting.swift; sourceTree = "<group>"; };
 		DC175F3F2718852A00D9D1FE /* DeleteStreamRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteStreamRequest.swift; sourceTree = "<group>"; };
 		DC1ED0EF26DFCD3C00FFA769 /* LiveBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveBadge.swift; sourceTree = "<group>"; };
 		DC1ED0F626E12C7400FFA769 /* ProgressHUD.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressHUD.swift; sourceTree = "<group>"; };
@@ -230,9 +230,9 @@
 			isa = PBXGroup;
 			children = (
 				DC175F2C270E232F00D9D1FE /* SyncManager.swift */,
-				DC175F3D2717530D00D9D1FE /* SyncStoring.swift */,
-				DC175F33270E3FD200D9D1FE /* SyncUsersStore.swift */,
-				DC175F31270E23F900D9D1FE /* ViewerStore.swift */,
+				DC175F3D2717530D00D9D1FE /* SyncObjectConnecting.swift */,
+				DC175F31270E23F900D9D1FE /* SyncUserDocument.swift */,
+				DC175F33270E3FD200D9D1FE /* SyncUsersMap.swift */,
 			);
 			path = Sync;
 			sourceTree = "<group>";
@@ -656,11 +656,11 @@
 				DC1ED0FD26E14D0B00FFA769 /* StreamToolbar.swift in Sources */,
 				DC1ED0F926E1440200FFA769 /* StreamStatusView.swift in Sources */,
 				DC504A7726F1468E00C37EC9 /* SpeakerVideoView.swift in Sources */,
-				DC175F34270E3FD200D9D1FE /* SyncUsersStore.swift in Sources */,
+				DC175F34270E3FD200D9D1FE /* SyncUsersMap.swift in Sources */,
 				DCC48FA326D8322900EE49EF /* SwiftUIPlayerView.swift in Sources */,
 				DC4F45E92723135500BE730B /* CardButtonLabel.swift in Sources */,
 				DC1ED0F726E12C7400FFA769 /* ProgressHUD.swift in Sources */,
-				DC175F32270E23F900D9D1FE /* ViewerStore.swift in Sources */,
+				DC175F32270E23F900D9D1FE /* SyncUserDocument.swift in Sources */,
 				DCC1D62626D9396400892038 /* StreamManager.swift in Sources */,
 				DCC48F9B26D8296300EE49EF /* LiveVideoError.swift in Sources */,
 				DC4F45EF27286AF300BE730B /* TipStyle.swift in Sources */,
@@ -672,7 +672,7 @@
 				DC1ED13026E960C600FFA769 /* SpeakerGridView.swift in Sources */,
 				DC5F458826CEA7CB009C5C79 /* SettingsView.swift in Sources */,
 				DC44BB3F2703C8AD00DB656D /* AppDelegate.swift in Sources */,
-				DC175F3E2717530D00D9D1FE /* SyncStoring.swift in Sources */,
+				DC175F3E2717530D00D9D1FE /* SyncObjectConnecting.swift in Sources */,
 				DC504A7526F0F18700C37EC9 /* SpeakerGridViewModel.swift in Sources */,
 				DC50A5752739E26300E29580 /* ViewerConnectedToPlayerRequest.swift in Sources */,
 				DCC48F8926D8288B00EE49EF /* APIErrorResponse.swift in Sources */,

--- a/apps/ios/LiveVideo/LiveVideo/Launch/LiveVideoApp.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Launch/LiveVideoApp.swift
@@ -29,15 +29,15 @@ struct LiveVideoApp: App {
                     let localParticipant = LocalParticipantManager(authManager: authManager)
                     let roomManager = RoomManager()
                     roomManager.configure(localParticipant: localParticipant)
-                    let viewerStore = ViewerStore()
-                    let speakersStore = SyncUsersStore()
-                    let raisedHandsStore = SyncUsersStore()
-                    let viewersStore = SyncUsersStore()
+                    let userDocument = SyncUserDocument()
+                    let speakersMap = SyncUsersMap()
+                    let raisedHandsMap = SyncUsersMap()
+                    let viewersMap = SyncUsersMap()
                     let syncManager = SyncManager(
-                        speakersStore: speakersStore,
-                        viewersStore: viewersStore,
-                        raisedHandsStore: raisedHandsStore,
-                        viewerStore: viewerStore
+                        speakersMap: speakersMap,
+                        viewersMap: viewersMap,
+                        raisedHandsMap: raisedHandsMap,
+                        userDocument: userDocument
                     )
                     streamManager.configure(
                         roomManager: roomManager,
@@ -49,18 +49,18 @@ struct LiveVideoApp: App {
                         streamManager: streamManager,
                         speakerSettingsManager: speakerSettingsManager,
                         api: api,
-                        viewerStore: viewerStore
+                        userDocument: userDocument
                     )
                     participantsViewModel.configure(
                         streamManager: streamManager,
                         api: api,
                         roomManager: roomManager,
-                        speakersStore: speakersStore,
-                        viewersStore: viewersStore,
-                        raisedHandsStore: raisedHandsStore
+                        speakersMap: speakersMap,
+                        viewersMap: viewersMap,
+                        raisedHandsMap: raisedHandsMap
                     )
                     speakerSettingsManager.configure(roomManager: roomManager)
-                    speakerGridViewModel.configure(roomManager: roomManager, speakersStore: speakersStore)
+                    speakerGridViewModel.configure(roomManager: roomManager, speakersMap: speakersMap)
                 }
         }
     }

--- a/apps/ios/LiveVideo/LiveVideo/Managers/API/CreateOrJoinStreamRequest.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Managers/API/CreateOrJoinStreamRequest.swift
@@ -15,7 +15,7 @@ struct CreateOrJoinStreamRequest: APIRequest {
             let speakersMap: String
             let viewersMap: String
             let raisedHandsMap: String
-            let viewerDocument: String?
+            let userDocument: String?
         }
         
         let token: String

--- a/apps/ios/LiveVideo/LiveVideo/Twilio/Stream/StreamManager.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Twilio/Stream/StreamManager.swift
@@ -112,7 +112,7 @@ class StreamManager: ObservableObject {
                     speakersMap: response.syncObjectNames.speakersMap,
                     viewersMap: response.syncObjectNames.viewersMap,
                     raisedHandsMap: response.syncObjectNames.raisedHandsMap,
-                    viewerDocument: response.syncObjectNames.viewerDocument
+                    userDocument: response.syncObjectNames.userDocument
                 )
                 
                 self?.connectSync(accessToken: response.token, objectNames: objectNames)

--- a/apps/ios/LiveVideo/LiveVideo/Twilio/Stream/StreamViewModel.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Twilio/Stream/StreamViewModel.swift
@@ -43,7 +43,7 @@ class StreamViewModel: ObservableObject {
     private var haveShownViewerConnectedAlert = false
     private var streamManager: StreamManager!
     private var api: API!
-    private var viewerStore: ViewerStore!
+    private var userDocument: SyncUserDocument!
     private var speakerSettingsManager: SpeakerSettingsManager!
     private var subscriptions = Set<AnyCancellable>()
 
@@ -51,12 +51,12 @@ class StreamViewModel: ObservableObject {
         streamManager: StreamManager,
         speakerSettingsManager: SpeakerSettingsManager,
         api: API,
-        viewerStore: ViewerStore
+        userDocument: SyncUserDocument
     ) {
         self.streamManager = streamManager
         self.speakerSettingsManager = speakerSettingsManager
         self.api = api
-        self.viewerStore = viewerStore
+        self.userDocument = userDocument
 
         streamManager.$state
             .sink { [weak self] state in
@@ -96,7 +96,7 @@ class StreamViewModel: ObservableObject {
             .sink { [weak self] error in self?.handleError(error) }
             .store(in: &subscriptions)
 
-        viewerStore.speakerInvitePublisher
+        userDocument.speakerInvitePublisher
             .sink { [weak self] in
                 self?.alertIdentifier = .receivedSpeakerInvite
             }

--- a/apps/ios/LiveVideo/LiveVideo/Twilio/Sync/SyncObjectConnecting.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Twilio/Sync/SyncObjectConnecting.swift
@@ -4,7 +4,7 @@
 
 import TwilioSyncClient
 
-protocol SyncStoring: AnyObject {
+protocol SyncObjectConnecting: AnyObject {
     var errorHandler: ((Error) -> Void)? { get set }
     func connect(client: TwilioSyncClient, completion: @escaping (Error?) -> Void)
     func disconnect()

--- a/apps/ios/LiveVideo/LiveVideo/Twilio/Sync/SyncUserDocument.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Twilio/Sync/SyncUserDocument.swift
@@ -5,7 +5,7 @@
 import Combine
 import TwilioSyncClient
 
-class ViewerStore: NSObject, SyncStoring, ObservableObject {
+class SyncUserDocument: NSObject, SyncObjectConnecting, ObservableObject {
     let speakerInvitePublisher = PassthroughSubject<Void, Never>()
     var uniqueName: String!
     var errorHandler: ((Error) -> Void)?
@@ -30,7 +30,7 @@ class ViewerStore: NSObject, SyncStoring, ObservableObject {
     }
 }
 
-extension ViewerStore: TWSDocumentDelegate {
+extension SyncUserDocument: TWSDocumentDelegate {
     func onDocument(
         _ document: TWSDocument,
         updated data: [String : Any],

--- a/apps/ios/LiveVideo/LiveVideo/Twilio/Sync/SyncUsersMap.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Twilio/Sync/SyncUsersMap.swift
@@ -8,7 +8,7 @@ import Combine
 /// Reusable store that fetches users from a sync map.
 ///
 /// Set `uniqueName` to specify the name of the sync map to fetch users from.
-class SyncUsersStore: NSObject, SyncStoring {
+class SyncUsersMap: NSObject, SyncObjectConnecting {
     struct User: Identifiable {
         let identity: String
         let isHost: Bool
@@ -63,7 +63,7 @@ class SyncUsersStore: NSObject, SyncStoring {
     }
 }
 
-extension SyncUsersStore: TWSMapDelegate {
+extension SyncUsersMap: TWSMapDelegate {
     func onMap(_ map: TWSMap, itemAdded item: TWSMapItem, eventContext: TWSEventContext) {
         let user = User(mapItem: item)
         users.append(user)

--- a/apps/ios/LiveVideo/LiveVideo/Views/Participants/ParticipantsView.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Views/Participants/ParticipantsView.swift
@@ -112,15 +112,15 @@ private extension ParticipantsViewModel {
         viewersWithoutRaisedHand: [String] = []
     ) -> ParticipantsViewModel {
         let viewModel = ParticipantsViewModel()
-        viewModel.speakers = speakers.map { SyncUsersStore.User(identity: $0) }
-        viewModel.viewersWithRaisedHand = viewersWithRaisedHand.map { SyncUsersStore.User(identity: $0) }
-        viewModel.viewersWithoutRaisedHand = viewersWithoutRaisedHand.map { SyncUsersStore.User(identity: $0) }
+        viewModel.speakers = speakers.map { SyncUsersMap.User(identity: $0) }
+        viewModel.viewersWithRaisedHand = viewersWithRaisedHand.map { SyncUsersMap.User(identity: $0) }
+        viewModel.viewersWithoutRaisedHand = viewersWithoutRaisedHand.map { SyncUsersMap.User(identity: $0) }
         viewModel.viewerCount = viewersWithRaisedHand.count + viewersWithoutRaisedHand.count
         return viewModel
     }
 }
 
-private extension SyncUsersStore.User {
+private extension SyncUsersMap.User {
     init(identity: String, isHost: Bool = false) {
         self.identity = identity
         self.isHost = isHost

--- a/apps/ios/LiveVideo/LiveVideo/Views/Stream/SpeakerGridViewModel.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Views/Stream/SpeakerGridViewModel.swift
@@ -11,12 +11,12 @@ class SpeakerGridViewModel: ObservableObject {
     @Published var offscreenSpeakers: [SpeakerVideoViewModel] = []
     private let maxOnscreenSpeakerCount = 6
     private var roomManager: RoomManager!
-    private var speakersStore: SyncUsersStore!
+    private var speakersMap: SyncUsersMap!
     private var subscriptions = Set<AnyCancellable>()
 
-    func configure(roomManager: RoomManager, speakersStore: SyncUsersStore) {
+    func configure(roomManager: RoomManager, speakersMap: SyncUsersMap) {
         self.roomManager = roomManager
-        self.speakersStore = speakersStore
+        self.speakersMap = speakersMap
         
         roomManager.roomConnectPublisher
             .sink { [weak self] in
@@ -112,17 +112,17 @@ class SpeakerGridViewModel: ObservableObject {
     }
     
     private func makeSpeaker(participant: LocalParticipantManager) -> SpeakerVideoViewModel {
-        let isHost = speakersStore.host?.identity == participant.identity
+        let isHost = speakersMap.host?.identity == participant.identity
         return SpeakerVideoViewModel(participant: participant, isHost: isHost)
     }
 
     private func makeSpeaker(participant: RemoteParticipantManager) -> SpeakerVideoViewModel {
-        let isHost = speakersStore.host?.identity == participant.identity
+        let isHost = speakersMap.host?.identity == participant.identity
         return SpeakerVideoViewModel(participant: participant, isHost: isHost)
     }
 }
 
-private extension SyncUsersStore {
+private extension SyncUsersMap {
     var host: User? {
         users.first { $0.isHost } // This app only has one host and it is the user that created the stream
     }

--- a/apps/web/src/components/Buttons/LeaveEventButton/LeaveEventButton.tsx
+++ b/apps/web/src/components/Buttons/LeaveEventButton/LeaveEventButton.tsx
@@ -26,7 +26,7 @@ export default function LeaveEventButton(props: { buttonClassName?: string }) {
   const { room } = useVideoContext();
   const { appState, appDispatch } = useAppState();
   const { connect: playerConnect } = usePlayerContext();
-  const { registerViewerDocument } = useSyncContext();
+  const { registerUserDocument } = useSyncContext();
 
   const anchorRef = useRef<HTMLButtonElement>(null);
 
@@ -34,7 +34,7 @@ export default function LeaveEventButton(props: { buttonClassName?: string }) {
     setMenuOpen(false);
     const { data } = await joinStreamAsViewer(appState.participantName, appState.eventName);
     await playerConnect(data.token);
-    registerViewerDocument(data.sync_object_names.viewer_document);
+    registerUserDocument(data.sync_object_names.user_document);
     room!.disconnect();
   }
 

--- a/apps/web/src/components/PreJoinScreens/PreJoinScreens.tsx
+++ b/apps/web/src/components/PreJoinScreens/PreJoinScreens.tsx
@@ -22,7 +22,7 @@ export default function PreJoinScreens() {
   const { connect: chatConnect } = useChatContext();
   const { connect: videoConnect } = useVideoContext();
   const { connect: playerConnect, disconnect: playerDisconnect } = usePlayerContext();
-  const { connect: syncConnect, registerViewerDocument, registerRaisedHandsMap } = useSyncContext();
+  const { connect: syncConnect, registerUserDocument, registerRaisedHandsMap } = useSyncContext();
   const [mediaError, setMediaError] = useState<Error>();
   const { appState, appDispatch } = useAppState();
   const enqueueSnackbar = useEnqueueSnackbar();
@@ -65,7 +65,7 @@ export default function PreJoinScreens() {
           const { data } = await joinStreamAsViewer(appState.participantName, appState.eventName);
           syncConnect(data.token);
           await playerConnect(data.token);
-          registerViewerDocument(data.sync_object_names.viewer_document);
+          registerUserDocument(data.sync_object_names.user_document);
           // chatConnect(data.token);
           break;
         }

--- a/apps/web/src/components/SyncProvider/index.tsx
+++ b/apps/web/src/components/SyncProvider/index.tsx
@@ -5,7 +5,7 @@ import { useAppState } from '../../state';
 
 type SyncContextType = {
   connect: (token: string) => void;
-  registerViewerDocument: (token: string) => Promise<void>;
+  registerUserDocument: (token: string) => Promise<void>;
   raisedHandsMap: SyncMap | undefined;
   registerRaisedHandsMap: (token: string) => Promise<void>;
 };
@@ -16,7 +16,7 @@ export const SyncProvider: React.FC = ({ children }) => {
   const { appDispatch } = useAppState();
   const { player } = usePlayerContext();
   const [raisedHandsMap, setRaisedHandsMap] = useState<SyncMap>();
-  const [viewerDocument, setViewerDocument] = useState<SyncDocument>();
+  const [userDocument, setUserDocument] = useState<SyncDocument>();
 
   const syncClientRef = useRef<SyncClient>();
 
@@ -24,8 +24,8 @@ export const SyncProvider: React.FC = ({ children }) => {
     syncClientRef.current = new SyncClient(token);
   }
 
-  function registerViewerDocument(viewerDocumentName: string) {
-    return syncClientRef.current!.document(viewerDocumentName).then(document => setViewerDocument(document));
+  function registerUserDocument(userDocumentName: string) {
+    return syncClientRef.current!.document(userDocumentName).then(document => setUserDocument(document));
   }
 
   function registerRaisedHandsMap(raisedHandsMapName: string) {
@@ -34,22 +34,22 @@ export const SyncProvider: React.FC = ({ children }) => {
 
   useEffect(() => {
     // The user can only accept a speaker invite when they are a viewer (when there is a player)
-    if (viewerDocument && player) {
+    if (userDocument && player) {
       const handleUpdate = (update: any) => {
         if (typeof update.data.speaker_invite !== 'undefined') {
           appDispatch({ type: 'set-has-speaker-invite', hasSpeakerInvite: update.data.speaker_invite });
         }
       };
 
-      viewerDocument.on('updated', handleUpdate);
+      userDocument.on('updated', handleUpdate);
       return () => {
-        viewerDocument.off('updated', handleUpdate);
+        userDocument.off('updated', handleUpdate);
       };
     }
-  }, [viewerDocument, player, appDispatch]);
+  }, [userDocument, player, appDispatch]);
 
   return (
-    <SyncContext.Provider value={{ connect, registerViewerDocument, raisedHandsMap, registerRaisedHandsMap }}>
+    <SyncContext.Provider value={{ connect, registerUserDocument, raisedHandsMap, registerRaisedHandsMap }}>
       {children}
     </SyncContext.Provider>
   );

--- a/apps/web/src/state/api/api.ts
+++ b/apps/web/src/state/api/api.ts
@@ -35,7 +35,7 @@ export const joinStreamAsViewer = (user_identity: string, stream_name: string) =
     room_sid: string;
     sync_object_names: {
       raised_hands_map: string;
-      viewer_document: string;
+      user_document: string;
     };
   }>('join-stream-as-viewer', {
     user_identity,

--- a/serverless/functions/join-stream-as-speaker.js
+++ b/serverless/functions/join-stream-as-speaker.js
@@ -75,11 +75,11 @@ module.exports.handler = async (context, event, callback) => {
 
   const streamSyncClient = client.sync.services(streamMapItem.data.sync_service_sid);
 
-  const viewerDocumentName = `viewer-${user_identity}`;
-  // Create viewer document
+  const userDocumentName = `user-${user_identity}`;
+  // Create user document
   try {
     await streamSyncClient.documents.create({
-      uniqueName: viewerDocumentName,
+      uniqueName: userDocumentName,
     });
   } catch (e) {
     // Ignore "Unique name already exists" error
@@ -88,7 +88,7 @@ module.exports.handler = async (context, event, callback) => {
       response.setStatusCode(500);
       response.setBody({
         error: {
-          message: 'error creating viewer document',
+          message: 'error creating user document',
           explanation: e.message,
         },
       });
@@ -96,16 +96,16 @@ module.exports.handler = async (context, event, callback) => {
     }
   }
 
-  // Give user read access to viewer document
+  // Give user read access to user document
   try {
-    await streamSyncClient.documents(viewerDocumentName)
+    await streamSyncClient.documents(userDocumentName)
       .documentPermissions(user_identity)
       .update({ read: true, write: false, manage: false })
   } catch (e) {
     response.setStatusCode(500);
     response.setBody({
       error: {
-        message: 'error adding read access to viewer document',
+        message: 'error adding read access to user document',
         explanation: e.message,
       },
     });
@@ -224,7 +224,7 @@ module.exports.handler = async (context, event, callback) => {
       speakers_map: 'speakers',
       viewers_map: 'viewers',
       raised_hands_map: `raised_hands`,
-      viewer_document: `viewer-${user_identity}`,
+      user_document: `user-${user_identity}`,
     },
   });
   return callback(null, response);

--- a/serverless/functions/join-stream-as-viewer.js
+++ b/serverless/functions/join-stream-as-viewer.js
@@ -37,7 +37,7 @@ module.exports.handler = async (context, event, callback) => {
     return callback(null, response);
   }
 
-  let room, streamMapItem, viewerDocument;
+  let room, streamMapItem, userDocument;
 
   const client = context.getTwilioClient();
 
@@ -72,11 +72,11 @@ module.exports.handler = async (context, event, callback) => {
 
   const streamSyncClient = client.sync.services(streamMapItem.data.sync_service_sid);
 
-  const viewerDocumentName = `viewer-${user_identity}`;
-  // Create viewer document
+  const userDocumentName = `user-${user_identity}`;
+  // Create user document
   try {
-    viewerDocument = await streamSyncClient.documents.create({
-      uniqueName: viewerDocumentName,
+    userDocument = await streamSyncClient.documents.create({
+      uniqueName: userDocumentName,
     });
   } catch (e) {
     // Ignore "Unique name already exists" error
@@ -85,7 +85,7 @@ module.exports.handler = async (context, event, callback) => {
       response.setStatusCode(500);
       response.setBody({
         error: {
-          message: 'error creating viewer document',
+          message: 'error creating user document',
           explanation: e.message,
         },
       });
@@ -93,11 +93,11 @@ module.exports.handler = async (context, event, callback) => {
     }
   }
 
-  // Update viewer document to set speaker_invite to false.
-  // This is done outside of the viewer document creation to account
-  // for viewers that may already have a viewer document
+  // Update user document to set speaker_invite to false.
+  // This is done outside of the user document creation to account
+  // for users that may already have a user document
   try {
-    await streamSyncClient.documents(viewerDocumentName).update({
+    await streamSyncClient.documents(userDocumentName).update({
       data: { speaker_invite: false },
     });
   } catch (e) {
@@ -105,23 +105,23 @@ module.exports.handler = async (context, event, callback) => {
     response.setStatusCode(500);
     response.setBody({
       error: {
-        message: 'error updating viewer  document',
+        message: 'error updating user  document',
         explanation: e.message,
       },
     });
     return callback(null, response);
   }
 
-  // Give user read access to viewer document
+  // Give user read access to user document
   try {
-    await streamSyncClient.documents(viewerDocumentName)
+    await streamSyncClient.documents(userDocumentName)
       .documentPermissions(user_identity)
       .update({ read: true, write: false, manage: false })
   } catch (e) {
     response.setStatusCode(500);
     response.setBody({
       error: {
-        message: 'error adding read access to viewer document',
+        message: 'error adding read access to user document',
         explanation: e.message,
       },
     });
@@ -222,7 +222,7 @@ module.exports.handler = async (context, event, callback) => {
       speakers_map: 'speakers',
       viewers_map: 'viewers',
       raised_hands_map: `raised_hands`,
-      viewer_document: `viewer-${user_identity}`,
+      user_document: `user-${user_identity}`,
     },
     room_sid: room.sid,
   });

--- a/serverless/functions/send-speaker-invite.js
+++ b/serverless/functions/send-speaker-invite.js
@@ -16,14 +16,14 @@ module.exports.handler = async (context, event, callback) => {
     // Set speaker_invite to true
     const streamMapItem = await getStreamMapItem(room_sid);
     const streamSyncClient = await client.sync.services(streamMapItem.data.sync_service_sid);
-    const doc = await streamSyncClient.documents(`viewer-${user_identity}`).fetch();
+    const doc = await streamSyncClient.documents(`user-${user_identity}`).fetch();
     await streamSyncClient.documents(doc.sid).update({ data: { ...doc.data, speaker_invite: true } });
   } catch (e) {
     console.error(e);
     response.setStatusCode(500);
     response.setBody({
       error: {
-        message: 'error updating viewer document',
+        message: 'error updating user document',
         explanation: e.message,
       },
     });


### PR DESCRIPTION
## Pull Request Details

### JIRA link(s):

- [VIDEO-7752](https://issues.corp.twilio.com/browse/VIDEO-7752)

### Description

These are the reasons for the rename:

1. Prevent confusion between similarly named sync objects. We have a `viewers` map and a `viewer-bob` document. It will be easier to describe these objects to customers if they have more distinct names. And so I have renamed to `user-bob` since it is unnecessary to scope this object to viewers only. 
2. Scoping to any user makes the object more general purpose which may be useful in the future. There is an argument that scoping to viewers is more self documenting for how the object is currently used but that seems like a minor tradeoff especially since the contents of the object should be intuitive.
3. In order to simplify sync setup on the clients we were already creating this object for both viewers and speakers when they join a stream. And so it's a little less strange to create a general purpose user object when a speaker joins.

Made changes to backend, iOS, and web. The backend and web changes were small. The iOS changes were larger because I needed to prevent other name confusion internal to iOS.

## Burndown

### Before review
* [ ] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with all effected platforms
* [x] Manually sanity tested running locally
* [x] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary