### PR TITLE
VIDEO-7604: Allow host to move speaker to viewers

### DIFF
--- a/apps/ios/LiveVideo/LiveVideo.xcodeproj/project.pbxproj
+++ b/apps/ios/LiveVideo/LiveVideo.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		DC1ED13026E960C600FFA769 /* SpeakerGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1ED12F26E960C600FFA769 /* SpeakerGridView.swift */; };
 		DC1ED13226E9666E00FFA769 /* SwiftUIVideoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1ED13126E9666E00FFA769 /* SwiftUIVideoView.swift */; };
 		DC3BB82527445F9A005D0327 /* ParticipantsHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3BB82427445F99005D0327 /* ParticipantsHeader.swift */; };
+		DC3BB82727480A9E005D0327 /* RemoveSpeakerRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3BB82627480A9E005D0327 /* RemoveSpeakerRequest.swift */; };
 		DC44BB3F2703C8AD00DB656D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC44BB3E2703C8AD00DB656D /* AppDelegate.swift */; };
 		DC44BB412703C8DD00DB656D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC44BB402703C8DD00DB656D /* SceneDelegate.swift */; };
 		DC4AA65926D0133600E677D5 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4AA65826D0133600E677D5 /* Color.swift */; };
@@ -121,6 +122,7 @@
 		DC1ED12F26E960C600FFA769 /* SpeakerGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakerGridView.swift; sourceTree = "<group>"; };
 		DC1ED13126E9666E00FFA769 /* SwiftUIVideoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIVideoView.swift; sourceTree = "<group>"; };
 		DC3BB82427445F99005D0327 /* ParticipantsHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantsHeader.swift; sourceTree = "<group>"; };
+		DC3BB82627480A9E005D0327 /* RemoveSpeakerRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveSpeakerRequest.swift; sourceTree = "<group>"; };
 		DC44BB3E2703C8AD00DB656D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DC44BB402703C8DD00DB656D /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		DC4AA65826D0133600E677D5 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
@@ -461,6 +463,7 @@
 				DC1ED12D26E94B5900FFA769 /* CreateOrJoinStreamRequest.swift */,
 				DC175F3F2718852A00D9D1FE /* DeleteStreamRequest.swift */,
 				DC6404D12719E549004730C6 /* RaiseHandRequest.swift */,
+				DC3BB82627480A9E005D0327 /* RemoveSpeakerRequest.swift */,
 				DC175F38270F673600D9D1FE /* SendSpeakerInviteRequest.swift */,
 				DC50A5742739E26300E29580 /* ViewerConnectedToPlayerRequest.swift */,
 			);
@@ -693,6 +696,7 @@
 				DC1ED0FB26E144AE00FFA769 /* StreamToolbarButton.swift in Sources */,
 				DC5F453926CC061A009C5C79 /* LiveVideoApp.swift in Sources */,
 				DC175F37270E5B6F00D9D1FE /* ParticipantsView.swift in Sources */,
+				DC3BB82727480A9E005D0327 /* RemoveSpeakerRequest.swift in Sources */,
 				DCC48F7726D8116C00EE49EF /* StreamView.swift in Sources */,
 				DC1ED11E26E92DEA00FFA769 /* LocalParticipantManager.swift in Sources */,
 				DC4F45EB2723695D00BE730B /* SelectRoleView.swift in Sources */,

--- a/apps/ios/LiveVideo/LiveVideo/Helpers/LiveVideoError.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Helpers/LiveVideoError.swift
@@ -6,22 +6,17 @@ import Foundation
 
 enum LiveVideoError: Error {
     case backendError(message: String)
+    case speakerMovedToViewersByHost
     case streamEndedByHost
     case syncClientConnectionFatalError
     case syncTokenExpired
-}
-
-extension LiveVideoError {
-    var isStreamEndedByHostError: Bool {
-        if case .streamEndedByHost = self { return true }
-        return false
-    }
 }
 
 extension LiveVideoError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case let .backendError(message): return message
+        case .speakerMovedToViewersByHost: return "Speaker moved to viewers by host."
         case .streamEndedByHost: return "Event ended by host."
         case .syncClientConnectionFatalError: return "Sync client connection fatal error."
         case .syncTokenExpired: return "Sync token expired."

--- a/apps/ios/LiveVideo/LiveVideo/Launch/LiveVideoApp.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Launch/LiveVideoApp.swift
@@ -60,7 +60,7 @@ struct LiveVideoApp: App {
                         raisedHandsMap: raisedHandsMap
                     )
                     speakerSettingsManager.configure(roomManager: roomManager)
-                    speakerGridViewModel.configure(roomManager: roomManager, speakersMap: speakersMap)
+                    speakerGridViewModel.configure(roomManager: roomManager, speakersMap: speakersMap, api: api)
                 }
         }
     }

--- a/apps/ios/LiveVideo/LiveVideo/Managers/API/RemoveSpeakerRequest.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Managers/API/RemoveSpeakerRequest.swift
@@ -1,0 +1,22 @@
+//
+//  Copyright (C) 2021 Twilio, Inc.
+//
+
+struct RemoveSpeakerRequest: APIRequest {
+    struct Parameters: Encodable {
+        let roomName: String
+        let userIdentity: String
+    }
+
+    struct Response: Decodable {
+        let removed: Bool
+    }
+
+    let path = "remove-speaker"
+    let parameters: Parameters
+    let responseType = Response.self
+    
+    init(roomName: String, userIdentity: String) {
+        parameters = Parameters(roomName: roomName, userIdentity: userIdentity)
+    }
+}

--- a/apps/ios/LiveVideo/LiveVideo/Twilio/Stream/StreamViewModel.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Twilio/Stream/StreamViewModel.swift
@@ -9,6 +9,7 @@ class StreamViewModel: ObservableObject {
     enum AlertIdentifier: String, Identifiable {
         case error
         case receivedSpeakerInvite
+        case speakerMovedToViewersByHost
         case streamEndedByHost
         case streamWillEndIfHostLeaves
         case viewerConnected
@@ -106,11 +107,32 @@ class StreamViewModel: ObservableObject {
     private func handleError(_ error: Error) {
         streamManager.disconnect()
         
-        if let error = error as? LiveVideoError, error.isStreamEndedByHostError {
+        if error.isStreamEndedByHostError {
             alertIdentifier = .streamEndedByHost
+        } else if error.isSpeakerMovedToViewersByHostError {
+            alertIdentifier = .speakerMovedToViewersByHost
+            streamManager.changeRole(to: .viewer)
         } else {
             self.error = error
             alertIdentifier = .error
         }
+    }
+}
+
+private extension Error {
+    var isSpeakerMovedToViewersByHostError: Bool {
+        if case .speakerMovedToViewersByHost = self as? LiveVideoError {
+            return true
+        }
+
+        return false
+    }
+
+    var isStreamEndedByHostError: Bool {
+        if case .streamEndedByHost = self as? LiveVideoError {
+            return true
+        }
+
+        return false
     }
 }

--- a/apps/ios/LiveVideo/LiveVideo/Views/Stream/SpeakerGridView.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Views/Stream/SpeakerGridView.swift
@@ -47,12 +47,18 @@ struct SpeakerGridView: View {
                     LazyVGrid(columns: columns, spacing: spacing) {
                         ForEach($viewModel.onscreenSpeakers, id: \.self) { $speaker in
                             Group {
-                                if role == .host && !speaker.isMuted && !speaker.isYou  {
+                                if role == .host && !speaker.isYou {
                                     Menu(
                                         content: {
+                                            if !speaker.isMuted {
+                                                Button(
+                                                    action: { viewModel.muteSpeaker(speaker) },
+                                                    label: { Label("Mute", systemImage: "mic.slash") }
+                                                )
+                                            }
                                             Button(
-                                                action: { viewModel.muteSpeaker(speaker) },
-                                                label: { Label("Mute", systemImage: "mic.slash") }
+                                                action: { viewModel.removeSpeaker(speaker) },
+                                                label: { Label("Move to viewers", systemImage: "minus.circle") }
                                             )
                                         },
                                         label: {

--- a/apps/ios/LiveVideo/LiveVideo/Views/Stream/SpeakerGridViewModel.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Views/Stream/SpeakerGridViewModel.swift
@@ -12,11 +12,13 @@ class SpeakerGridViewModel: ObservableObject {
     private let maxOnscreenSpeakerCount = 6
     private var roomManager: RoomManager!
     private var speakersMap: SyncUsersMap!
+    private var api: API!
     private var subscriptions = Set<AnyCancellable>()
 
-    func configure(roomManager: RoomManager, speakersMap: SyncUsersMap) {
+    func configure(roomManager: RoomManager, speakersMap: SyncUsersMap, api: API) {
         self.roomManager = roomManager
         self.speakersMap = speakersMap
+        self.api = api
         
         roomManager.roomConnectPublisher
             .sink { [weak self] in
@@ -66,6 +68,15 @@ class SpeakerGridViewModel: ObservableObject {
         roomManager.localParticipant.sendMessage(message)
     }
 
+    func removeSpeaker(_ speaker: SpeakerVideoViewModel) {
+        guard let roomName = roomManager.roomName else {
+            return
+        }
+        
+        let request = RemoveSpeakerRequest(roomName: roomName, userIdentity: speaker.identity)
+        api.request(request)
+    }
+    
     private func addSpeaker(_ speaker: SpeakerVideoViewModel) {
         if onscreenSpeakers.count < maxOnscreenSpeakerCount {
             onscreenSpeakers.append(speaker)

--- a/apps/ios/LiveVideo/LiveVideo/Views/Stream/StreamView.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Views/Stream/StreamView.swift
@@ -152,6 +152,12 @@ struct StreamView: View {
                         viewModel.isHandRaised = false
                     }
                 )
+            case .speakerMovedToViewersByHost:
+                return Alert(
+                    title: Text("Moved to viewers"),
+                    message: Text("You have been moved to viewers by the host."),
+                    dismissButton: .default(Text("OK"))
+                )
             case .streamEndedByHost:
                 return Alert(
                     title: Text("Event is no longer available"),

--- a/serverless/functions/remove-speaker.js
+++ b/serverless/functions/remove-speaker.js
@@ -1,0 +1,26 @@
+exports.handler = async function (context, event, callback) {
+  let response = new Twilio.Response();
+  response.appendHeader('Content-Type', 'application/json');
+
+  const client = context.getTwilioClient();
+
+  try {
+    await client.video.rooms(event.room_name).participants(event.user_identity).update({ status: 'disconnected' })
+  } catch (e) {
+    console.error(e);
+    response.setStatusCode(500);
+    response.setBody({
+      error: {
+        message: 'error removing speaker',
+        explanation: e.message,
+      }
+    });
+    return callback(null, response);
+  }
+
+  response.setBody({
+    removed: true,
+  });
+
+  callback(null, response);
+};


### PR DESCRIPTION
## Pull Request Details

### JIRA link(s):

- [VIDEO-7604](https://issues.corp.twilio.com/browse/VIDEO-7604)

### Description

1. Add feature for host to move speaker to viewers. The mechanics are the same as the live audio app.
2. Note that the ordering of the items in the menu depends if the system decides to display the menu above or below the view that is tapped. In the code the remove speaker item is last in the menu. But in the video it is displayed first so that it is furthest from the tap location and the menu is displayed above the tap.

## Burndown

### Before review
* [ ] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with all effected platforms
* [x] Manually sanity tested running locally
* [x] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary

https://user-images.githubusercontent.com/1930363/142695545-6ac965f7-ef49-421b-a6d8-25b22e32dae3.mov