### PR TITLE
Fix media issue on event join

### DIFF
--- a/apps/web/src/components/PreJoinScreens/DeviceSelectionScreen/DeviceSelectionScreen.tsx
+++ b/apps/web/src/components/PreJoinScreens/DeviceSelectionScreen/DeviceSelectionScreen.tsx
@@ -107,7 +107,13 @@ export default function DeviceSelectionScreen({ state, dispatch, connect }: Devi
               <Button variant="outlined" color="primary" onClick={handleGoBack}>
                 Go Back
               </Button>
-              <Button variant="contained" color="primary" data-cy-join-now onClick={connect}>
+              <Button
+                variant="contained"
+                color="primary"
+                data-cy-join-now
+                onClick={connect}
+                disabled={isAcquiringLocalTracks}
+              >
                 {state.participantType === 'host' ? 'Create Event' : 'Join Event'}
               </Button>
             </div>


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- N/A

### Description

This pull request prevents users from joining an event before their media devices have been acquired. Previously, users could join a room while the device permissions window was still pending, which meant that they were not able to publish audio or video in the event. Now, the "Join Event" button is disabled until the users audio and video tracks have been acquired.

![image](https://user-images.githubusercontent.com/12685223/143071753-97b995fb-f0fc-4928-901d-09191b1e92ce.png)


## Burndown

### Before review
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with all effected platforms
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary