### PR TITLE
add correct network quality

### DIFF
--- a/apps/web/src/components/MainParticipantInfo/MainParticipantInfo.tsx
+++ b/apps/web/src/components/MainParticipantInfo/MainParticipantInfo.tsx
@@ -157,7 +157,7 @@ export default function MainParticipantInfo({ participant, children }: MainParti
               {screenSharePublication && ' - Screen'}
             </Typography>
           </div>
-          <NetworkQualityLevel participant={localParticipant} />
+          <NetworkQualityLevel participant={participant} />
         </div>
         {isRecording && (
           <Tooltip


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VIDEO-8123](https://issues.corp.twilio.com/browse/VIDEO-8123)

### Description

This PR fixes a small bug where the `<MainParticipant />`'s network quality indicator would always show the network quality of the local participant. With this fix, the `<MainParticipant />` will always show the network quality specific to the participant that is the active main participant.

## Burndown

### Before review
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with all effected platforms
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary