### PR TITLE
Increment iOS app version

### DIFF
--- a/apps/ios/LiveVideo/LiveVideo/Info.plist
+++ b/apps/ios/LiveVideo/LiveVideo/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>0.1.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/apps/ios/LiveVideo/LiveVideoTests/Info.plist
+++ b/apps/ios/LiveVideo/LiveVideoTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.1.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/apps/ios/LiveVideo/LiveVideoUITests/Info.plist
+++ b/apps/ios/LiveVideo/LiveVideoUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.1.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
Just increment the iOS app version to prevent install confusion. I used `fastlane run increment_version_number` so this has been done in very standard way.