### PR TITLE
iOS move host controls to menu button

### DIFF
--- a/apps/ios/LiveVideo/LiveVideo.xcodeproj/project.pbxproj
+++ b/apps/ios/LiveVideo/LiveVideo.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		DC6404D4271B3BF8004730C6 /* StreamViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6404D3271B3BF8004730C6 /* StreamViewModel.swift */; };
 		DC6404D8271B68D4004730C6 /* ParticipantsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6404D7271B68D4004730C6 /* ParticipantsViewModel.swift */; };
 		DC6404DA271E217C004730C6 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DC6404D9271E217B004730C6 /* LaunchScreen.storyboard */; };
+		DC83671327BABF7500A90BF2 /* HostControlsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC83671227BABF7500A90BF2 /* HostControlsManager.swift */; };
 		DC9E18372729B68B0070F53F /* TitleStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9E18362729B68B0070F53F /* TitleStyle.swift */; };
 		DC9E18392729DC740070F53F /* OffscreenSpeakersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9E18382729DC740070F53F /* OffscreenSpeakersView.swift */; };
 		DCB1BDFE27568D70006CE9D1 /* VerifyPasscodeRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCB1BDFD27568D70006CE9D1 /* VerifyPasscodeRequest.swift */; };
@@ -173,6 +174,7 @@
 		DC6404D3271B3BF8004730C6 /* StreamViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamViewModel.swift; sourceTree = "<group>"; };
 		DC6404D7271B68D4004730C6 /* ParticipantsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantsViewModel.swift; sourceTree = "<group>"; };
 		DC6404D9271E217B004730C6 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		DC83671227BABF7500A90BF2 /* HostControlsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostControlsManager.swift; sourceTree = "<group>"; };
 		DC9E18362729B68B0070F53F /* TitleStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleStyle.swift; sourceTree = "<group>"; };
 		DC9E18382729DC740070F53F /* OffscreenSpeakersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OffscreenSpeakersView.swift; sourceTree = "<group>"; };
 		DCB1BDFD27568D70006CE9D1 /* VerifyPasscodeRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifyPasscodeRequest.swift; sourceTree = "<group>"; };
@@ -305,6 +307,7 @@
 				DCC48F7826D8288B00EE49EF /* API */,
 				DC4AA65526D0125900E677D5 /* AppInfo */,
 				DC4AA66326D1454A00E677D5 /* Auth */,
+				DC83671427BAD78400A90BF2 /* HostControls */,
 				DC14B78626FA385E003BDABC /* SpeakerSettings */,
 				DC4AA65626D0126A00E677D5 /* UserDefaults */,
 			);
@@ -439,6 +442,14 @@
 				DC5F455726CC061F009C5C79 /* Info.plist */,
 			);
 			path = LiveVideoUITests;
+			sourceTree = "<group>";
+		};
+		DC83671427BAD78400A90BF2 /* HostControls */ = {
+			isa = PBXGroup;
+			children = (
+				DC83671227BABF7500A90BF2 /* HostControlsManager.swift */,
+			);
+			path = HostControls;
 			sourceTree = "<group>";
 		};
 		DCC1D62426D9393900892038 /* Stream */ = {
@@ -727,6 +738,7 @@
 				DC1ED13026E960C600FFA769 /* SpeakerGridView.swift in Sources */,
 				DC5F458826CEA7CB009C5C79 /* SettingsView.swift in Sources */,
 				DC44BB3F2703C8AD00DB656D /* AppDelegate.swift in Sources */,
+				DC83671327BABF7500A90BF2 /* HostControlsManager.swift in Sources */,
 				DC175F3E2717530D00D9D1FE /* SyncObjectConnecting.swift in Sources */,
 				DC504A7526F0F18700C37EC9 /* SpeakerGridViewModel.swift in Sources */,
 				DC50A5752739E26300E29580 /* ViewerConnectedToPlayerRequest.swift in Sources */,

--- a/apps/ios/LiveVideo/LiveVideo/Launch/LiveVideoApp.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Launch/LiveVideoApp.swift
@@ -12,6 +12,7 @@ struct LiveVideoApp: App {
     @StateObject private var participantsViewModel = ParticipantsViewModel()
     @StateObject private var streamManager = StreamManager()
     @StateObject private var speakerSettingsManager = SpeakerSettingsManager()
+    @StateObject private var hostControlsManager = HostControlsManager()
     @StateObject private var speakerGridViewModel = SpeakerGridViewModel()
     @StateObject private var presentationLayoutViewModel = PresentationLayoutViewModel()
     @StateObject private var api = API()
@@ -26,6 +27,7 @@ struct LiveVideoApp: App {
                 .environmentObject(speakerGridViewModel)
                 .environmentObject(presentationLayoutViewModel)
                 .environmentObject(speakerSettingsManager)
+                .environmentObject(hostControlsManager)
                 .environmentObject(api)
                 .onAppear {
                     authManager.configure(api: api)
@@ -64,11 +66,11 @@ struct LiveVideoApp: App {
                         raisedHandsMap: raisedHandsMap
                     )
                     speakerSettingsManager.configure(roomManager: roomManager)
+                    hostControlsManager.configure(roomManager: roomManager, api: api)
                     speakerVideoViewModelFactory.configure(speakersMap: speakersMap)
                     speakerGridViewModel.configure(
                         roomManager: roomManager,
                         speakersMap: speakersMap,
-                        api: api,
                         speakerVideoViewModelFactory: speakerVideoViewModelFactory
                     )
                     presentationLayoutViewModel.configure(

--- a/apps/ios/LiveVideo/LiveVideo/Managers/HostControls/HostControlsManager.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Managers/HostControls/HostControlsManager.swift
@@ -1,0 +1,29 @@
+//
+//  Copyright (C) 2022 Twilio, Inc.
+//
+
+import Foundation
+
+class HostControlsManager: ObservableObject {
+    private var roomManager: RoomManager!
+    private var api: API!
+
+    func configure(roomManager: RoomManager, api: API) {
+        self.roomManager = roomManager
+        self.api = api
+    }
+    
+    func muteSpeaker(identity: String) {
+        let message = RoomMessage(messageType: .mute, toParticipantIdentity: identity)
+        roomManager.localParticipant.sendMessage(message)
+    }
+
+    func removeSpeaker(identity: String) {
+        guard let roomName = roomManager.roomName else {
+            return
+        }
+        
+        let request = RemoveSpeakerRequest(roomName: roomName, userIdentity: identity)
+        api.request(request)
+    }
+}

--- a/apps/ios/LiveVideo/LiveVideo/Views/Stream/PresentationLayout/PresentationLayoutView.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Views/Stream/PresentationLayout/PresentationLayoutView.swift
@@ -9,6 +9,7 @@ struct PresentationLayoutView: View {
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
     @Environment(\.verticalSizeClass) var verticalSizeClass
     let spacing: CGFloat
+    let role: StreamConfig.Role
 
     private var isPortraitOrientation: Bool {
         verticalSizeClass == .regular && horizontalSizeClass == .compact
@@ -19,7 +20,7 @@ struct PresentationLayoutView: View {
             HStack(spacing: spacing) {
                 VStack(spacing: spacing) {
                     PresentationStatusView(presenterDisplayName: viewModel.presenter.displayName)
-                    SpeakerVideoView(speaker: $viewModel.dominantSpeaker)
+                    SpeakerVideoView(speaker: $viewModel.dominantSpeaker, showHostControls: role == .host)
 
                     if isPortraitOrientation {
                         PresentationVideoView(videoTrack: $viewModel.presenter.presentationTrack)
@@ -40,10 +41,10 @@ struct PresentationLayoutView: View {
 struct PresentationLayoutView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            PresentationLayoutView(spacing: 6)
+            PresentationLayoutView(spacing: 6, role: .speaker)
                 .previewDisplayName("Portrait")
                 .frame(width: 300, height: 600)
-            PresentationLayoutView(spacing: 6)
+            PresentationLayoutView(spacing: 6, role: .speaker)
                 .previewDisplayName("Landscape")
                 .frame(width: 600, height: 300)
         }

--- a/apps/ios/LiveVideo/LiveVideo/Views/Stream/SpeakerGridView.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Views/Stream/SpeakerGridView.swift
@@ -46,30 +46,8 @@ struct SpeakerGridView: View {
                 GeometryReader { geometry in
                     LazyVGrid(columns: columns, spacing: spacing) {
                         ForEach($viewModel.onscreenSpeakers, id: \.self) { $speaker in
-                            Group {
-                                if role == .host && !speaker.isYou {
-                                    Menu(
-                                        content: {
-                                            if !speaker.isMuted {
-                                                Button(
-                                                    action: { viewModel.muteSpeaker(speaker) },
-                                                    label: { Label("Mute", systemImage: "mic.slash") }
-                                                )
-                                            }
-                                            Button(
-                                                action: { viewModel.removeSpeaker(speaker) },
-                                                label: { Label("Move to viewers", systemImage: "minus.circle") }
-                                            )
-                                        },
-                                        label: {
-                                            SpeakerVideoView(speaker: $speaker)
-                                        }
-                                    )
-                                } else {
-                                    SpeakerVideoView(speaker: $speaker)
-                                }
-                            }
-                            .frame(height: geometry.size.height / CGFloat(rowCount) - spacing)
+                            SpeakerVideoView(speaker: $speaker, showHostControls: role == .host)
+                                .frame(height: geometry.size.height / CGFloat(rowCount) - spacing)
                         }
                     }
                 }
@@ -82,13 +60,13 @@ struct SpeakerGridView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
             ForEach((1...6), id: \.self) {
-                SpeakerGridView(spacing: 6, role: .host)
+                SpeakerGridView(spacing: 6, role: .speaker)
                     .environmentObject(SpeakerGridViewModel.stub(onscreenSpeakerCount: $0))
             }
             .frame(width: 400, height: 700)
 
             ForEach((1...6), id: \.self) {
-                SpeakerGridView(spacing: 6, role: .host)
+                SpeakerGridView(spacing: 6, role: .speaker)
                     .environmentObject(SpeakerGridViewModel.stub(onscreenSpeakerCount: $0))
             }
             .frame(width: 700, height: 300)

--- a/apps/ios/LiveVideo/LiveVideo/Views/Stream/SpeakerGridViewModel.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Views/Stream/SpeakerGridViewModel.swift
@@ -12,19 +12,16 @@ class SpeakerGridViewModel: ObservableObject {
     private let maxOnscreenSpeakerCount = 6
     private var roomManager: RoomManager!
     private var speakersMap: SyncUsersMap!
-    private var api: API!
     private var speakerVideoViewModelFactory: SpeakerVideoViewModelFactory!
     private var subscriptions = Set<AnyCancellable>()
 
     func configure(
         roomManager: RoomManager,
         speakersMap: SyncUsersMap,
-        api: API,
         speakerVideoViewModelFactory: SpeakerVideoViewModelFactory
     ) {
         self.roomManager = roomManager
         self.speakersMap = speakersMap
-        self.api = api
         self.speakerVideoViewModelFactory = speakerVideoViewModelFactory
         
         roomManager.roomConnectPublisher
@@ -71,20 +68,6 @@ class SpeakerGridViewModel: ObservableObject {
 
                 self.updateSpeaker(self.speakerVideoViewModelFactory.makeSpeaker(participant: participant)) }
             .store(in: &subscriptions)
-    }
-
-    func muteSpeaker(_ speaker: SpeakerVideoViewModel) {
-        let message = RoomMessage(messageType: .mute, toParticipantIdentity: speaker.identity)
-        roomManager.localParticipant.sendMessage(message)
-    }
-
-    func removeSpeaker(_ speaker: SpeakerVideoViewModel) {
-        guard let roomName = roomManager.roomName else {
-            return
-        }
-        
-        let request = RemoveSpeakerRequest(roomName: roomName, userIdentity: speaker.identity)
-        api.request(request)
     }
     
     private func addSpeaker(_ speaker: SpeakerVideoViewModel) {

--- a/apps/ios/LiveVideo/LiveVideo/Views/Stream/SpeakerVideoView.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Views/Stream/SpeakerVideoView.swift
@@ -5,7 +5,9 @@
 import SwiftUI
 
 struct SpeakerVideoView: View {
+    @EnvironmentObject var hostControlsManager: HostControlsManager
     @Binding var speaker: SpeakerVideoViewModel
+    let showHostControls: Bool
     
     var body: some View {
         ZStack {
@@ -35,7 +37,7 @@ struct SpeakerVideoView: View {
                     }
                 }
                 Spacer()
-                HStack {
+                HStack(alignment: .bottom) {
                     Text(speaker.displayName)
                         .lineLimit(1)
                         .foregroundColor(.white)
@@ -45,6 +47,29 @@ struct SpeakerVideoView: View {
                         .cornerRadius(2)
                         .font(.system(size: 14))
                     Spacer()
+
+                    if showHostControls && !speaker.isYou {
+                        Menu(
+                            content: {
+                                if !speaker.isMuted {
+                                    Button(
+                                        action: { hostControlsManager.muteSpeaker(identity: speaker.identity) },
+                                        label: { Label("Mute", systemImage: "mic.slash") }
+                                    )
+                                }
+                                Button(
+                                    action: { hostControlsManager.removeSpeaker(identity: speaker.identity) },
+                                    label: { Label("Move to viewers", systemImage: "minus.circle") }
+                                )
+                            },
+                            label: {
+                                Image(systemName: "ellipsis")
+                                    .foregroundColor(.white)
+                                    .font(.system(size: 22, weight: .heavy))
+                                    .frame(minWidth: 44, minHeight: 44)
+                            }
+                        )
+                    }
                 }
                 .padding(4)
             }
@@ -62,15 +87,19 @@ struct SpeakerVideoView: View {
 
 struct SpeakerVideoView_Previews: PreviewProvider {
     static var previews: some View {
+        let longIdentity = String(repeating: "Long ", count: 20)
+        
         Group {
-            SpeakerVideoView(speaker: .constant(SpeakerVideoViewModel()))
-                .previewDisplayName("Not Muted")
-            SpeakerVideoView(speaker: .constant(SpeakerVideoViewModel(identity: String(repeating: "Long ", count: 20))))
-                .previewDisplayName("Long Identity")
-            SpeakerVideoView(speaker: .constant(SpeakerVideoViewModel(isMuted: true)))
+            SpeakerVideoView(speaker: .constant(SpeakerVideoViewModel()), showHostControls: true)
+                .previewDisplayName("Not muted")
+            SpeakerVideoView(speaker: .constant(SpeakerVideoViewModel(identity: longIdentity)), showHostControls: true)
+                .previewDisplayName("Long identity")
+            SpeakerVideoView(speaker: .constant(SpeakerVideoViewModel(identity: longIdentity)), showHostControls: false)
+                .previewDisplayName("Long identity without host controls")
+            SpeakerVideoView(speaker: .constant(SpeakerVideoViewModel(isMuted: true)), showHostControls: true)
                 .previewDisplayName("Muted")
-            SpeakerVideoView(speaker: .constant(SpeakerVideoViewModel(isDominantSpeaker: true)))
-                .previewDisplayName("Dominant Speaker")
+            SpeakerVideoView(speaker: .constant(SpeakerVideoViewModel(isDominantSpeaker: true)), showHostControls: true)
+                .previewDisplayName("Dominant speaker")
         }
         .frame(width: 200, height: 200)
         .previewLayout(.sizeThatFits)

--- a/apps/ios/LiveVideo/LiveVideo/Views/Stream/StreamView.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Views/Stream/StreamView.swift
@@ -36,7 +36,7 @@ struct StreamView: View {
                             switch streamManager.config.role {
                             case .host, .speaker:
                                 if presentationLayoutViewModel.isPresenting {
-                                    PresentationLayoutView(spacing: spacing)
+                                    PresentationLayoutView(spacing: spacing, role: streamManager.config.role)
                                 } else {
                                     SpeakerGridView(spacing: spacing, role: streamManager.config.role)
                                 }


### PR DESCRIPTION
The host controls menu allow the host to mute other speakers or force other speakers back to the audience. Previously the menu was accessed by tapping on a speaker video tile which was not easy for users to discover. The host controls menu is now accessed by tapping on a `...` button that is overlaid on each speaker video tile.

The code to show the menu has also been refactored to be inside the `SpeakerVideoView` so it is agnostic of video layout. And so the menu can now be accessed when using the new presentation layout.

New menu button:
![Simulator Screen Shot - iPhone 13 Pro - 2022-02-14 at 11 25 41](https://user-images.githubusercontent.com/1930363/153926275-30965e8a-08d3-4a76-8e9f-2cf8607ac8a0.png)

Menu button tap:
![Simulator Screen Shot - iPhone 13 Pro - 2022-02-14 at 11 25 57](https://user-images.githubusercontent.com/1930363/153926280-e79f79af-25f9-47ec-8d1d-76e7e00a5c49.png)

Menu button on presentation layout:
![Simulator Screen Shot - iPhone 13 Pro - 2022-02-14 at 11 29 26](https://user-images.githubusercontent.com/1930363/153926283-f810f9f6-db67-4ff7-b2d9-c4e64a96e3db.png)
