### PR TITLE
Update functions to support recording

### DIFF
--- a/serverless/functions/create-stream.js
+++ b/serverless/functions/create-stream.js
@@ -56,6 +56,14 @@ module.exports.handler = async (context, event, callback) => {
 
   const client = context.getTwilioClient();
 
+  room = await client.video.rooms
+    .create({
+      uniqueName: stream_name,
+      type: 'group',
+      statusCallback: 'https://' + DOMAIN_NAME + '/rooms-webhook',
+    })
+    .catch(createErrorHandler('error creating room.'));
+
   // Create stream sync service
   streamSyncService = await client.sync.services
     .create({
@@ -88,14 +96,6 @@ module.exports.handler = async (context, event, callback) => {
     .documentPermissions(user_identity)
     .update({ read: true, write: false, manage: false })
     .catch(createErrorHandler('error adding read access to stream document.'));
-
-  room = await client.video.rooms
-    .create({
-      uniqueName: stream_name,
-      type: 'group',
-      statusCallback: 'https://' + DOMAIN_NAME + '/rooms-webhook',
-    })
-    .catch(createErrorHandler('error creating room.'));
 
   // Create playerStreamer
   playerStreamer = await axiosClient('PlayerStreamers', {

--- a/serverless/functions/create-stream.js
+++ b/serverless/functions/create-stream.js
@@ -245,12 +245,6 @@ module.exports.handler = async (context, event, callback) => {
   response.setStatusCode(200);
   response.setBody({
     token: token.toJwt(),
-    sync_object_names: {
-      speakers_map: 'speakers',
-      viewers_map: 'viewers',
-      raised_hands_map: 'raised_hands',
-      stream_document: 'stream',
-    },
   });
   return callback(null, response);
 };

--- a/serverless/functions/create-stream.js
+++ b/serverless/functions/create-stream.js
@@ -140,12 +140,10 @@ module.exports.handler = async (context, event, callback) => {
     })
     .catch(createErrorHandler('error adding stream to streams map.'));
 
-  const speakersMapName = `speakers`;
-
   // Create speakers map
   await streamSyncClient.syncMaps
     .create({
-      uniqueName: speakersMapName,
+      uniqueName: 'speakers',
     })
     .catch(createErrorHandler('error creating speakers map.'));
 
@@ -167,38 +165,35 @@ module.exports.handler = async (context, event, callback) => {
 
   // Give user read access to speakers map
   await streamSyncClient
-    .syncMaps(speakersMapName)
+    .syncMaps('speakers')
     .syncMapPermissions(user_identity)
     .update({ read: true, write: false, manage: false })
     .catch(createErrorHandler('error adding read access to speakers map.'));
 
-  const raisedHandsMapName = `raised_hands`;
   // Create raised hands map
   await streamSyncClient.syncMaps
     .create({
-      uniqueName: raisedHandsMapName,
+      uniqueName: 'raised_hands',
     })
     .catch(createErrorHandler('error creating raised hands map.'));
 
   // Give user read access to raised hands map
   await streamSyncClient
-    .syncMaps(raisedHandsMapName)
+    .syncMaps('raised_hands')
     .syncMapPermissions(user_identity)
     .update({ read: true, write: false, manage: false })
     .catch(createErrorHandler('error adding read access to raised hands map.'));
 
-  const viewersMapName = `viewers`;
-
   // Create viewers map
   await streamSyncClient.syncMaps
     .create({
-      uniqueName: viewersMapName,
+      uniqueName: 'viewers',
     })
     .catch(createErrorHandler('error creating viewers map.'));
 
   // Give user read access to viewers map
   await streamSyncClient
-    .syncMaps(viewersMapName)
+    .syncMaps('viewers')
     .syncMapPermissions(user_identity)
     .update({ read: true, write: false, manage: false })
     .catch(createErrorHandler('error adding read access to viewers map.'));
@@ -220,6 +215,7 @@ module.exports.handler = async (context, event, callback) => {
     .conversations(room.sid)
     .participants.create({ identity: user_identity })
     .catch((error) => {
+      // Ignore "Participant already exists" error (50433)
       if (error.code !== 50433) {
         createErrorHandler('error creating stream sync service.')(error);
       }
@@ -252,7 +248,8 @@ module.exports.handler = async (context, event, callback) => {
     sync_object_names: {
       speakers_map: 'speakers',
       viewers_map: 'viewers',
-      raised_hands_map: `raised_hands`,
+      raised_hands_map: 'raised_hands',
+      stream_document: 'stream',
     },
   });
   return callback(null, response);

--- a/serverless/functions/delete-stream.js
+++ b/serverless/functions/delete-stream.js
@@ -5,29 +5,19 @@ exports.handler = async function (context, event, callback) {
   authHandler(context, event, callback);
 
   const common = require(Runtime.getAssets()['/common.js'].path);
-  const { axiosClient, response } = common(context, event, callback);
+  const { response, createErrorHandler } = common(context, event, callback);
 
   const client = context.getTwilioClient();
-  const backendStrageSyncClient = client.sync.services(context.BACKEND_STORAGE_SYNC_SERVICE_SID);
 
   const { stream_name } = event;
 
-  try {
-    // End the video room which will cause everything else to be cleaned up in the rooms webhook
-    await client.video.rooms(stream_name).update({ status: 'completed' });
+  // End the video room which will cause everything else to be cleaned up in the rooms webhook
+  await client.video
+    .rooms(stream_name)
+    .update({ status: 'completed' })
+    .catch(createErrorHandler('error deleting stream'));
 
-    console.log('deleted: ', stream_name);
-  } catch (e) {
-    console.log(e);
-    response.setStatusCode(500);
-    response.setBody({
-      error: {
-        message: 'error deleting stream',
-        explanation: e.message,
-      },
-    });
-    return callback(null, response);
-  }
+  console.log('deleted: ', stream_name);
 
   response.setBody({
     deleted: true,

--- a/serverless/functions/join-stream-as-speaker.js
+++ b/serverless/functions/join-stream-as-speaker.js
@@ -8,8 +8,7 @@ const SyncGrant = AccessToken.SyncGrant;
 const MAX_ALLOWED_SESSION_DURATION = 14400;
 
 module.exports.handler = async (context, event, callback) => {
-  const { ACCOUNT_SID, TWILIO_API_KEY_SID, TWILIO_API_KEY_SECRET, CONVERSATIONS_SERVICE_SID } =
-    context;
+  const { ACCOUNT_SID, TWILIO_API_KEY_SID, TWILIO_API_KEY_SECRET, CONVERSATIONS_SERVICE_SID } = context;
 
   const authHandler = require(Runtime.getAssets()['/auth.js'].path);
   authHandler(context, event, callback);
@@ -17,7 +16,7 @@ module.exports.handler = async (context, event, callback) => {
   const { user_identity, stream_name } = event;
 
   const common = require(Runtime.getAssets()['/common.js'].path);
-  const { getStreamMapItem } = common(context, event, callback);
+  const { getStreamMapItem, createErrorHandler } = common(context, event, callback);
 
   let response = new Twilio.Response();
   response.appendHeader('Content-Type', 'application/json');
@@ -48,156 +47,80 @@ module.exports.handler = async (context, event, callback) => {
 
   const client = context.getTwilioClient();
 
-  try {
-    // See if a room already exists
-    room = await client.video.rooms(stream_name).fetch();
-  } catch (e) {
-    response.setStatusCode(500);
-    response.setBody({
-      error: {
-        message: 'error finding room',
-        explanation: e.message,
-      },
-    });
-    return callback(null, response);
-  }
+  // See if a room already exists
+  room = await client.video.rooms(stream_name).fetch().catch(createErrorHandler('error finding room'));
 
   // Fetch stream map item
-  try {
-    streamMapItem = await getStreamMapItem(room.sid);
-  } catch (e) {
-    response.setStatusCode(500);
-    response.setBody({
-      error: {
-        message: 'error finding stream map item',
-        explanation: e.message,
-      },
-    });
-    return callback(null, response);
-  }
+  streamMapItem = await getStreamMapItem(room.sid).catch(createErrorHandler('error finding stream map item'));
 
   const streamSyncClient = client.sync.services(streamMapItem.data.sync_service_sid);
 
   const userDocumentName = `user-${user_identity}`;
   // Create user document
-  try {
-    await streamSyncClient.documents.create({
+  await streamSyncClient.documents
+    .create({
       uniqueName: userDocumentName,
+    })
+    .catch((error) => {
+      // Ignore "Unique name already exists" error
+      if (error.code !== 54301) {
+        createErrorHandler('error creating user document')(error);
+      }
     });
-  } catch (e) {
-    // Ignore "Unique name already exists" error
-    if (e.code !== 54301) {
-      console.error(e);
-      response.setStatusCode(500);
-      response.setBody({
-        error: {
-          message: 'error creating user document',
-          explanation: e.message,
-        },
-      });
-      return callback(null, response);
-    }
-  }
+
+  // Give user read access to stream document
+  await streamSyncClient
+    .documents('stream')
+    .documentPermissions(user_identity)
+    .update({ read: true, write: false, manage: false })
+    .catch(createErrorHandler('error adding read access to stream document.'));
 
   // Give user read access to user document
-  try {
-    await streamSyncClient.documents(userDocumentName)
-      .documentPermissions(user_identity)
-      .update({ read: true, write: false, manage: false })
-  } catch (e) {
-    response.setStatusCode(500);
-    response.setBody({
-      error: {
-        message: 'error adding read access to user document',
-        explanation: e.message,
-      },
-    });
-    return callback(null, response);
-  }
-  
+  await streamSyncClient
+    .documents(userDocumentName)
+    .documentPermissions(user_identity)
+    .update({ read: true, write: false, manage: false })
+    .catch(createErrorHandler('error adding read access to user document'));
+
   // Give user read access to speakers map
-  try {
-    await streamSyncClient.syncMaps('speakers')
-      .syncMapPermissions(user_identity)
-      .update({ read: true, write: false, manage: false })
-  } catch (e) {
-    response.setStatusCode(500);
-    response.setBody({
-      error: {
-        message: 'error adding read access to speakers map',
-        explanation: e.message,
-      },
-    });
-    return callback(null, response);
-  }
-  
-  const raisedHandsMapName = `raised_hands`;
+  await streamSyncClient
+    .syncMaps('speakers')
+    .syncMapPermissions(user_identity)
+    .update({ read: true, write: false, manage: false })
+    .catch(createErrorHandler('error adding read access to speakers map'));
+
   // Give user read access to raised hands map
-  try {
-    await streamSyncClient.syncMaps(raisedHandsMapName)
-      .syncMapPermissions(user_identity)
-      .update({ read: true, write: false, manage: false });
-  } catch (e) {
-    response.setStatusCode(500);
-    response.setBody({
-      error: {
-        message: 'error adding read access to raised hands map',
-        explanation: e.message,
-      },
-    });
-    return callback(null, response);
-  }
+  await streamSyncClient
+    .syncMaps('raised_hands')
+    .syncMapPermissions(user_identity)
+    .update({ read: true, write: false, manage: false })
+    .catch(createErrorHandler('error adding read access to raised hands map'));
 
   // Give user read access to viewers map
-  try {
-    await streamSyncClient.syncMaps('viewers')
-      .syncMapPermissions(user_identity)
-      .update({ read: true, write: false, manage: false })
-  } catch (e) {
-    response.setStatusCode(500);
-    response.setBody({
-      error: {
-        message: 'error adding read access to viewers map',
-        explanation: e.message,
-      },
-    });
-    return callback(null, response);
-  }
+  await streamSyncClient
+    .syncMaps('viewers')
+    .syncMapPermissions(user_identity)
+    .update({ read: true, write: false, manage: false })
+    .catch(createErrorHandler('error adding read access to viewers map'));
 
   const conversationsClient = client.conversations.services(CONVERSATIONS_SERVICE_SID);
 
-  try {
-    // Find conversation
-    conversation = await conversationsClient.conversations(room.sid).fetch();
-  } catch (e) {
-    console.error(e);
-    response.setStatusCode(500);
-    response.setBody({
-      error: {
-        message: 'error finding conversation',
-        explanation: 'Something went wrong when finding a conversation.',
-      },
-    });
-    return callback(null, response);
-  }
+  // Find conversation
+  conversation = await conversationsClient
+    .conversations(room.sid)
+    .fetch()
+    .catch(createErrorHandler('error finding conversation'));
 
-  try {
-    // Add participant to conversation
-    await conversationsClient.conversations(room.sid).participants.create({ identity: user_identity });
-  } catch (e) {
-    // Ignore "Participant already exists" error (50433)
-    if (e.code !== 50433) {
-      console.error(e);
-      response.setStatusCode(500);
-      response.setBody({
-        error: {
-          message: 'error creating conversation participant',
-          explanation: 'Something went wrong when creating a conversation participant.',
-        },
-      });
-      return callback(null, response);
-    }
-  }
+  // Add participant to conversation
+  await conversationsClient
+    .conversations(room.sid)
+    .participants.create({ identity: user_identity })
+    .catch((error) => {
+      // Ignore "Participant already exists" error (50433)
+      if (error.code !== 50433) {
+        createErrorHandler('error adding read access to user document')(error);
+      }
+    });
 
   // Create token
   const token = new AccessToken(ACCOUNT_SID, TWILIO_API_KEY_SID, TWILIO_API_KEY_SECRET, {
@@ -226,8 +149,9 @@ module.exports.handler = async (context, event, callback) => {
     sync_object_names: {
       speakers_map: 'speakers',
       viewers_map: 'viewers',
-      raised_hands_map: `raised_hands`,
-      user_document: `user-${user_identity}`,
+      raised_hands_map: 'raised_hands',
+      user_document: userDocumentName,
+      stream_document: 'stream',
     },
   });
   return callback(null, response);

--- a/serverless/functions/join-stream-as-speaker.js
+++ b/serverless/functions/join-stream-as-speaker.js
@@ -118,7 +118,7 @@ module.exports.handler = async (context, event, callback) => {
     .catch((error) => {
       // Ignore "Participant already exists" error (50433)
       if (error.code !== 50433) {
-        createErrorHandler('error adding read access to user document')(error);
+        createErrorHandler('error creating conversation participant')(error);
       }
     });
 

--- a/serverless/functions/join-stream-as-speaker.js
+++ b/serverless/functions/join-stream-as-speaker.js
@@ -146,13 +146,6 @@ module.exports.handler = async (context, event, callback) => {
   response.setStatusCode(200);
   response.setBody({
     token: token.toJwt(),
-    sync_object_names: {
-      speakers_map: 'speakers',
-      viewers_map: 'viewers',
-      raised_hands_map: 'raised_hands',
-      user_document: userDocumentName,
-      stream_document: 'stream',
-    },
   });
   return callback(null, response);
 };

--- a/serverless/functions/join-stream-as-viewer.js
+++ b/serverless/functions/join-stream-as-viewer.js
@@ -11,7 +11,7 @@ module.exports.handler = async (context, event, callback) => {
   authHandler(context, event, callback);
 
   const common = require(Runtime.getAssets()['/common.js'].path);
-  const { getPlaybackGrant, getStreamMapItem } = common(context, event, callback);
+  const { getPlaybackGrant, getStreamMapItem, createErrorHandler } = common(context, event, callback);
 
   const { user_identity, stream_name } = event;
 
@@ -44,155 +44,75 @@ module.exports.handler = async (context, event, callback) => {
 
   const client = context.getTwilioClient();
 
-  try {
-    // See if a room already exists
-    room = await client.video.rooms(stream_name).fetch();
-  } catch (e) {
-    console.error(e);
-    response.setStatusCode(500);
-    response.setBody({
-      error: {
-        message: 'error finding room',
-        explanation: e.message,
-      },
-    });
-    return callback(null, response);
-  }
+  // See if a room already exists
+  room = await client.video.rooms(stream_name).fetch().catch(createErrorHandler('error finding room'));
 
   // Fetch stream map item
-  try {
-    streamMapItem = await getStreamMapItem(room.sid);
-  } catch (e) {
-    response.setStatusCode(500);
-    response.setBody({
-      error: {
-        message: 'error fetching stream map item',
-        explanation: e.message,
-      },
-    });
-    return callback(null, response);
-  }
+  streamMapItem = await getStreamMapItem(room.sid).catch(createErrorHandler('error finding stream map item'));
 
   const streamSyncClient = client.sync.services(streamMapItem.data.sync_service_sid);
 
+  // Give user read access to stream document
+  await streamSyncClient
+    .documents('stream')
+    .documentPermissions(user_identity)
+    .update({ read: true, write: false, manage: false })
+    .catch(createErrorHandler('error adding read access to stream document.'));
+
   const userDocumentName = `user-${user_identity}`;
   // Create user document
-  try {
-    userDocument = await streamSyncClient.documents.create({
+  userDocument = await streamSyncClient.documents
+    .create({
       uniqueName: userDocumentName,
+    })
+    .catch((error) => {
+      // Ignore "Unique name already exists" error
+      if (error.code !== 54301) {
+        createErrorHandler('error creating user document');
+      }
     });
-  } catch (e) {
-    // Ignore "Unique name already exists" error
-    if (e.code !== 54301) {
-      console.error(e);
-      response.setStatusCode(500);
-      response.setBody({
-        error: {
-          message: 'error creating user document',
-          explanation: e.message,
-        },
-      });
-      return callback(null, response);
-    }
-  }
 
   // Update user document to set speaker_invite to false.
   // This is done outside of the user document creation to account
   // for users that may already have a user document
-  try {
-    await streamSyncClient.documents(userDocumentName).update({
+  await streamSyncClient
+    .documents(userDocumentName)
+    .update({
       data: { speaker_invite: false },
-    });
-  } catch (e) {
-    console.error(e);
-    response.setStatusCode(500);
-    response.setBody({
-      error: {
-        message: 'error updating user  document',
-        explanation: e.message,
-      },
-    });
-    return callback(null, response);
-  }
+    })
+    .catch(createErrorHandler('error updating user document'));
 
   // Give user read access to user document
-  try {
-    await streamSyncClient.documents(userDocumentName)
-      .documentPermissions(user_identity)
-      .update({ read: true, write: false, manage: false });
-  } catch (e) {
-    response.setStatusCode(500);
-    response.setBody({
-      error: {
-        message: 'error adding read access to user document',
-        explanation: e.message,
-      },
-    });
-    return callback(null, response);
-  }
+  await streamSyncClient
+    .documents(userDocumentName)
+    .documentPermissions(user_identity)
+    .update({ read: true, write: false, manage: false })
+    .catch(createErrorHandler('error adding read access to user document'));
 
   // Give user read access to speakers map
-  try {
-    await streamSyncClient.syncMaps('speakers')
-      .syncMapPermissions(user_identity)
-      .update({ read: true, write: false, manage: false })
-  } catch (e) {
-    response.setStatusCode(500);
-    response.setBody({
-      error: {
-        message: 'error adding read access to speakers map',
-        explanation: e.message,
-      },
-    });
-    return callback(null, response);
-  }
-  
+  await streamSyncClient
+    .syncMaps('speakers')
+    .syncMapPermissions(user_identity)
+    .update({ read: true, write: false, manage: false })
+    .catch(createErrorHandler('error adding read access to speakers map'));
+
   // Give user read access to raised hands map
-  try {
-    await streamSyncClient.syncMaps(`raised_hands`)
-      .syncMapPermissions(user_identity)
-      .update({ read: true, write: false, manage: false });
-  } catch (e) {
-    response.setStatusCode(500);
-    response.setBody({
-      error: {
-        message: 'error adding read access to raised hands map',
-        explanation: e.message,
-      },
-    });
-    return callback(null, response);
-  }
+  await streamSyncClient
+    .syncMaps('raised_hands')
+    .syncMapPermissions(user_identity)
+    .update({ read: true, write: false, manage: false })
+    .catch(createErrorHandler('error adding read access to raised hands map'));
 
   // Give user read access to viewers map
-  try {
-    await streamSyncClient.syncMaps('viewers')
-      .syncMapPermissions(user_identity)
-      .update({ read: true, write: false, manage: false })
-  } catch (e) {
-    response.setStatusCode(500);
-    response.setBody({
-      error: {
-        message: 'error adding read access to viewers map',
-        explanation: e.message,
-      },
-    });
-    return callback(null, response);
-  }
-  
-  let playbackGrant;
-  try {
-    playbackGrant = await getPlaybackGrant(streamMapItem.data.player_streamer_sid);
-  } catch (e) {
-    console.error(e);
-    response.setStatusCode(500);
-    response.setBody({
-      error: {
-        message: 'error getting playback grant',
-        explanation: e.message,
-      },
-    });
-    return callback(null, response);
-  }
+  await streamSyncClient
+    .syncMaps('viewers')
+    .syncMapPermissions(user_identity)
+    .update({ read: true, write: false, manage: false })
+    .catch(createErrorHandler('error adding read access to viewers map'));
+
+  const playbackGrant = await getPlaybackGrant(streamMapItem.data.player_streamer_sid).catch(
+    createErrorHandler('error getting playback grant')
+  );
 
   // Create token
   const token = new AccessToken(context.ACCOUNT_SID, context.TWILIO_API_KEY_SID, context.TWILIO_API_KEY_SECRET, {
@@ -226,8 +146,9 @@ module.exports.handler = async (context, event, callback) => {
     sync_object_names: {
       speakers_map: 'speakers',
       viewers_map: 'viewers',
-      raised_hands_map: `raised_hands`,
-      user_document: `user-${user_identity}`,
+      raised_hands_map: 'raised_hands',
+      user_document: userDocumentName,
+      stream_document: 'stream',
     },
     room_sid: room.sid,
   });

--- a/serverless/functions/join-stream-as-viewer.js
+++ b/serverless/functions/join-stream-as-viewer.js
@@ -143,13 +143,6 @@ module.exports.handler = async (context, event, callback) => {
   response.setStatusCode(200);
   response.setBody({
     token: token.toJwt(),
-    sync_object_names: {
-      speakers_map: 'speakers',
-      viewers_map: 'viewers',
-      raised_hands_map: 'raised_hands',
-      user_document: userDocumentName,
-      stream_document: 'stream',
-    },
     room_sid: room.sid,
   });
 

--- a/serverless/functions/media-processor-webhook.js
+++ b/serverless/functions/media-processor-webhook.js
@@ -21,7 +21,7 @@ exports.handler = async function (context, event, callback) {
     createErrorHandler('error getting the stream client.')(e);
   }
 
-  if (recording_error) {
+  if (recording_error === 'true') {
     const doc = await streamSyncClient.documents('stream').fetch();
     await streamSyncClient
       .documents(doc.sid)

--- a/serverless/functions/media-processor-webhook.js
+++ b/serverless/functions/media-processor-webhook.js
@@ -2,7 +2,7 @@
 
 exports.handler = async function (context, event, callback) {
   const common = require(Runtime.getAssets()['/common.js'].path);
-  const { axiosClient, response, getStreamMapItem, createErrorHandler } = common(context, event, callback);
+  const { getStreamMapItem, createErrorHandler } = common(context, event, callback);
 
   const client = context.getTwilioClient();
 
@@ -25,7 +25,7 @@ exports.handler = async function (context, event, callback) {
     const doc = await streamSyncClient.documents('stream').fetch();
     await streamSyncClient
       .documents(doc.sid)
-      .update({ data: { ...doc.data, recording: { is_recording: false, error: 'A recording error has occured' } } })
+      .update({ data: { ...doc.data, recording: { is_recording: false, error: 'A recording error has occurred' } } })
       .catch(createErrorHandler('error updating stream document'));
   }
 

--- a/serverless/functions/media-processor-webhook.js
+++ b/serverless/functions/media-processor-webhook.js
@@ -1,0 +1,33 @@
+'use strict';
+
+exports.handler = async function (context, event, callback) {
+  const common = require(Runtime.getAssets()['/common.js'].path);
+  const { axiosClient, response, getStreamMapItem, createErrorHandler } = common(context, event, callback);
+
+  const client = context.getTwilioClient();
+
+  const { recording_error = false, stream_name } = event;
+
+  let streamSyncClient;
+
+  // See if a room already exists
+  const room = await client.video.rooms(stream_name).fetch().catch(createErrorHandler('error finding room'));
+
+  // Get stream sync client
+  try {
+    let streamMapItem = await getStreamMapItem(room.sid);
+    streamSyncClient = await client.sync.services(streamMapItem.data.sync_service_sid);
+  } catch (e) {
+    createErrorHandler('error getting the stream client.')(e);
+  }
+
+  if (recording_error) {
+    const doc = await streamSyncClient.documents('stream').fetch();
+    await streamSyncClient
+      .documents(doc.sid)
+      .update({ data: { ...doc.data, recording: { is_recording: false, error: 'A recording error has occured' } } })
+      .catch(createErrorHandler('error updating stream document'));
+  }
+
+  callback(null, 'ok');
+};

--- a/serverless/functions/rooms-webhook.protected.js
+++ b/serverless/functions/rooms-webhook.protected.js
@@ -2,7 +2,7 @@
 
 exports.handler = async function (context, event, callback) {
   const common = require(Runtime.getAssets()['/common.js'].path);
-  const { axiosClient, response, getStreamMapItem } = common(context, event, callback);
+  const { axiosClient, response, getStreamMapItem, createErrorHandler } = common(context, event, callback);
 
   const client = context.getTwilioClient();
 
@@ -22,73 +22,46 @@ exports.handler = async function (context, event, callback) {
         const streamMapItem = await getStreamMapItem(RoomSid);
         streamSyncClient = await client.sync.services(streamMapItem.data.sync_service_sid);
       } catch (e) {
-        console.error(e);
-        response.setStatusCode(500);
-        response.setBody({
-          error: {
-            message: 'error getting stream sync client',
-            explanation: e.message,
-          },
-        });
-        return callback(null, response);
+        createErrorHandler('error getting stream sync client')(e);
       }
 
       // Remove user from viewers map
-      try {
-        await streamSyncClient.syncMaps('viewers').syncMapItems(event.ParticipantIdentity).remove();
-      } catch (e) {
-        if (e.code !== notFoundError) {
-          console.error(e);
-          response.setStatusCode(500);
-          response.setBody({
-            error: {
-              message: 'error removing user from viewers map',
-              explanation: e.message,
-            },
-          });
-          return callback(null, response);
-        }
-      }
+
+      await streamSyncClient
+        .syncMaps('viewers')
+        .syncMapItems(event.ParticipantIdentity)
+        .remove()
+        .catch((e) => {
+          if (e.code !== notFoundError) {
+            createErrorHandler('error removing user from viewers map')(e);
+          }
+        });
 
       // Remove user from raised hands map
-      try {
-        await streamSyncClient.syncMaps('raised_hands').syncMapItems(event.ParticipantIdentity).remove();
-      } catch (e) {
-        if (e.code !== notFoundError) {
-          console.error(e);
-          response.setStatusCode(500);
-          response.setBody({
-            error: {
-              message: 'error removing user from raised hands map',
-              explanation: e.message,
-            },
-          });
-          return callback(null, response);
-        }
-      }
+      await streamSyncClient
+        .syncMaps('raised_hands')
+        .syncMapItems(event.ParticipantIdentity)
+        .remove()
+        .catch((e) => {
+          if (e.code !== notFoundError) {
+            createErrorHandler('error removing user from raised hands map')(e);
+          }
+        });
 
       // Add user to the speakers map. There is only one host and they are added to the speakers map
       // when the stream is created. So all new speakers that are added here will not be host.
-      try {
-        await streamSyncClient.syncMaps('speakers').syncMapItems.create({
+      await streamSyncClient
+        .syncMaps('speakers')
+        .syncMapItems.create({
           key: event.ParticipantIdentity,
           data: { host: false },
+        })
+        .catch((e) => {
+          const alreadyExistsError = 54208;
+          if (e.code !== alreadyExistsError) {
+            createErrorHandler('error adding user to speakers map')(e);
+          }
         });
-      } catch (e) {
-        const alreadyExistsError = 54208;
-
-        if (e.code !== alreadyExistsError) {
-          console.error(e);
-          response.setStatusCode(500);
-          response.setBody({
-            error: {
-              message: 'error adding user to speakers map',
-              explanation: e.message,
-            },
-          });
-          return callback(null, response);
-        }
-      }
 
       break;
     case 'participant-disconnected':
@@ -101,33 +74,19 @@ exports.handler = async function (context, event, callback) {
         const streamMapItem = await getStreamMapItem(RoomSid);
         streamSyncClient = await client.sync.services(streamMapItem.data.sync_service_sid);
       } catch (e) {
-        console.error(e);
-        response.setStatusCode(500);
-        response.setBody({
-          error: {
-            message: 'error getting stream sync client',
-            explanation: e.message,
-          },
-        });
-        return callback(null, response);
+        createErrorHandler('error getting stream sync client')(e);
       }
 
       // Remove user from speakers map
-      try {
-        await streamSyncClient.syncMaps('speakers').syncMapItems(event.ParticipantIdentity).remove();
-      } catch (e) {
-        if (e.code !== notFoundError) {
-          console.error(e);
-          response.setStatusCode(500);
-          response.setBody({
-            error: {
-              message: 'error removing user from speakers map',
-              explanation: e.message,
-            },
-          });
-          return callback(null, response);
-        }
-      }
+      await streamSyncClient
+        .syncMaps('speakers')
+        .syncMapItems(event.ParticipantIdentity)
+        .remove()
+        .catch((e) => {
+          if (e.code !== notFoundError) {
+            createErrorHandler('error removing user from speakers map')(e);
+          }
+        });
 
       break;
     case 'room-ended':
@@ -161,18 +120,11 @@ exports.handler = async function (context, event, callback) {
         console.log('Ended MediaProcessor: ', media_processor_sid);
         console.log('Ended PlayerStreamer: ', player_streamer_sid);
       } catch (e) {
-        console.log(e);
-        response.setStatusCode(500);
-        response.setBody({
-          error: {
-            message: 'error deleting stream',
-            explanation: e.message,
-          },
-        });
-        return callback(null, response);
+        createErrorHandler('error deleting stream')(e);
       }
 
       break;
+
     default:
       break;
   }

--- a/serverless/functions/sync-webhook.protected.js
+++ b/serverless/functions/sync-webhook.protected.js
@@ -2,78 +2,50 @@
 
 exports.handler = async function (context, event, callback) {
   const common = require(Runtime.getAssets()['/common.js'].path);
-  const { response } = common(context, event, callback);
+  const { response, createErrorHandler } = common(context, event, callback);
   const client = context.getTwilioClient();
 
   if (event.EventType === 'endpoint_disconnected') {
     const notFoundError = 20404;
-    let streamSyncClient;
- 
+
     // Get stream sync client
-    try {
-      streamSyncClient = await client.sync.services(event.ServiceSid);
-    } catch (e) {
-      console.error(e);
-      response.setStatusCode(500);
-      response.setBody({
-        error: {
-          message: 'error getting stream sync client',
-          explanation: e.message,
-        },
-      });
-      return callback(null, response);
-    }
+    const streamSyncClient = await client.sync
+      .services(event.ServiceSid)
+      .catch(createErrorHandler('error getting stream sync client'));
 
     // Remove user from speakers map
-    try {
-      await streamSyncClient.syncMaps('speakers').syncMapItems(event.Identity).remove();
-    } catch (e) {
-      if (e.code !== notFoundError) {
-        console.error(e);
-        response.setStatusCode(500);
-        response.setBody({
-          error: {
-            message: 'error removing user from speakers map',
-            explanation: e.message,
-          },
-        });
-        return callback(null, response);
-      }
-    }
+    await streamSyncClient
+      .syncMaps('speakers')
+      .syncMapItems(event.Identity)
+      .remove()
+      .catch((e) => {
+        if (e.code !== notFoundError) {
+          createErrorHandler('error removing user from speakers map')(e);
+        }
+      });
 
     // Remove user from raised hands map
-    try {
-      await streamSyncClient.syncMaps('raised_hands').syncMapItems(event.Identity).remove();
-    } catch (e) {
-      if (e.code !== notFoundError) {
-        console.error(e);
-        response.setStatusCode(500);
-        response.setBody({
-          error: {
-            message: 'error removing user from raised hands map',
-            explanation: e.message,
-          },
-        });
-        return callback(null, response);
-      }
-    }
+
+    await streamSyncClient
+      .syncMaps('raised_hands')
+      .syncMapItems(event.Identity)
+      .remove()
+      .catch((e) => {
+        if (e.code !== notFoundError) {
+          createErrorHandler('error removing user from raised hands map')(e);
+        }
+      });
 
     // Remove user from viewers map
-    try {
-      await streamSyncClient.syncMaps('viewers').syncMapItems(event.Identity).remove();
-    } catch (e) {
-      if (e.code !== notFoundError) {
-        console.error(e);
-        response.setStatusCode(500);
-        response.setBody({
-          error: {
-            message: 'error removing user from viewers map',
-            explanation: e.message,
-          },
-        });
-        return callback(null, response);
-      }
-    }
+    await streamSyncClient
+      .syncMaps('viewers')
+      .syncMapItems(event.Identity)
+      .remove()
+      .catch((e) => {
+        if (e.code !== notFoundError) {
+          createErrorHandler('error removing user from viewers map')(e);
+        }
+      });
   }
 
   return callback(null, response);

--- a/serverless/middleware/common.private.js
+++ b/serverless/middleware/common.private.js
@@ -7,7 +7,7 @@ module.exports = (context, event, callback) => {
   response.appendHeader('Content-Type', 'application/json');
 
   const client = context.getTwilioClient();
-  const region = client.region;  
+  const region = client.region;
 
   const axiosClient = axios.create({
     headers: {
@@ -32,10 +32,27 @@ module.exports = (context, event, callback) => {
     return mapItem;
   }
 
+  function createErrorHandler(errorMessage) {
+    return (error) => {
+      let response = new Twilio.Response();
+      response.appendHeader('Content-Type', 'application/json');
+      console.error(error);
+      response.setStatusCode(500);
+      response.setBody({
+        error: {
+          message: errorMessage,
+          explanation: error.message,
+        },
+      });
+      return callback(null, response);
+    };
+  }
+
   return {
     axiosClient,
     response,
     getPlaybackGrant,
-    getStreamMapItem
+    getStreamMapItem,
+    createErrorHandler,
   };
 };


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

This PR adds functionality to the serverless functions to add support for recording. It also refactors the error handling logic to simplify the functions and remove much repetitive code.

To support recording, we create a new Sync Document called the "stream document", which contains information about the state of the stream recording. It can also contain more information down the road if needed.

This stream document is created when a [host creates a stream](https://github.com/twilio/twilio-live-interactive-video/pull/111/commits/71e6a95c33c1762629413ea19f2318da6b2c44a0#diff-afa617e9349b3f351ce76d266070c8e83247f405c623458ac3a1a37956dfabe7R73-R90). The `is_recording` boolean in the stream document is set to the value of the `record_stream` parameter that is a part of the request. 

Note: recording isn't started in the create-stream function. This will come in a later PR. 

This PR also [adds a fake](https://github.com/twilio/twilio-live-interactive-video/pull/111/commits/816d80db2fef6e9de26e0b5dd9a00c70291fc96b) `media-processor-webhook` function. This function will eventually be registered as a media processor webhook, but for now it can be used to trigger a fake recording error in the stream-document. This is useful to test the error reporting UI in the apps, for instance, if you visit this endpoint in your browser:

`https://twilio-live-interactive-video-xxxx-yyyy-dev.twil.io/media-processor-webhook?stream_name=test-stream&recording_error=true`

It will save an error message to the stream-document, which can then trigger an error message in the apps.

This PR also contains a significant refactor of all error handling. It's quite a lot of code to review, but it greatly reduces the size of each file while improving its readability. 

## Burndown

### Before review
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with all effected platforms
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary