### PR TITLE
Add iOS chat SDK

### DIFF
--- a/apps/ios/LiveVideo/LiveVideo.xcodeproj/project.pbxproj
+++ b/apps/ios/LiveVideo/LiveVideo.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		DC0A95F62819DB7500E7678C /* TwilioConversationsClient in Frameworks */ = {isa = PBXBuildFile; productRef = DC0A95F52819DB7500E7678C /* TwilioConversationsClient */; };
+		DC0A95F92819E1C800E7678C /* ChatManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0A95F82819E1C800E7678C /* ChatManager.swift */; };
+		DC0A96052819E2C600E7678C /* ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0A96042819E2C600E7678C /* ChatMessage.swift */; };
+		DC0A9607281B2F0F00E7678C /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0A9606281B2F0F00E7678C /* ChatView.swift */; };
 		DC175F2D270E232F00D9D1FE /* SyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC175F2C270E232F00D9D1FE /* SyncManager.swift */; };
 		DC175F30270E238F00D9D1FE /* TwilioSyncClient in Frameworks */ = {isa = PBXBuildFile; productRef = DC175F2F270E238F00D9D1FE /* TwilioSyncClient */; };
 		DC175F32270E23F900D9D1FE /* SyncUserDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC175F31270E23F900D9D1FE /* SyncUserDocument.swift */; };
@@ -115,6 +119,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		DC0A95F82819E1C800E7678C /* ChatManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatManager.swift; sourceTree = "<group>"; };
+		DC0A96042819E2C600E7678C /* ChatMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessage.swift; sourceTree = "<group>"; };
+		DC0A9606281B2F0F00E7678C /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		DC175F2C270E232F00D9D1FE /* SyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncManager.swift; sourceTree = "<group>"; };
 		DC175F31270E23F900D9D1FE /* SyncUserDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncUserDocument.swift; sourceTree = "<group>"; };
 		DC175F33270E3FD200D9D1FE /* SyncUsersMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncUsersMap.swift; sourceTree = "<group>"; };
@@ -209,6 +216,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DC0A95F62819DB7500E7678C /* TwilioConversationsClient in Frameworks */,
 				DCC48F9826D828E500EE49EF /* Alamofire in Frameworks */,
 				DC4F45E7271F5A3700BE730B /* TwilioLivePlayer in Frameworks */,
 				DCB1BE032756A288006CE9D1 /* KeychainAccess in Frameworks */,
@@ -236,6 +244,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		DC0A95F72819E19100E7678C /* Chat */ = {
+			isa = PBXGroup;
+			children = (
+				DC0A95F82819E1C800E7678C /* ChatManager.swift */,
+				DC0A96042819E2C600E7678C /* ChatMessage.swift */,
+				DC0A9606281B2F0F00E7678C /* ChatView.swift */,
+			);
+			path = Chat;
+			sourceTree = "<group>";
+		};
 		DC14B78626FA385E003BDABC /* SpeakerSettings */ = {
 			isa = PBXGroup;
 			children = (
@@ -517,6 +535,7 @@
 		DCC48F9E26D830D300EE49EF /* Twilio */ = {
 			isa = PBXGroup;
 			children = (
+				DC0A95F72819E19100E7678C /* Chat */,
 				DCC48F9F26D830E300EE49EF /* Player */,
 				DC1ED0FE26E92D7C00FFA769 /* Room */,
 				DCC1D62426D9393900892038 /* Stream */,
@@ -575,6 +594,7 @@
 				DC175F2F270E238F00D9D1FE /* TwilioSyncClient */,
 				DC4F45E6271F5A3700BE730B /* TwilioLivePlayer */,
 				DCB1BE022756A288006CE9D1 /* KeychainAccess */,
+				DC0A95F52819DB7500E7678C /* TwilioConversationsClient */,
 			);
 			productName = LiveVideo;
 			productReference = DC5F453526CC061A009C5C79 /* LiveVideo.app */;
@@ -659,6 +679,7 @@
 				DCB1BE012756A288006CE9D1 /* XCRemoteSwiftPackageReference "KeychainAccess" */,
 				DCB1BE0627581BC6006CE9D1 /* XCRemoteSwiftPackageReference "Quick" */,
 				DCB1BE0927581C11006CE9D1 /* XCRemoteSwiftPackageReference "Nimble" */,
+				DC0A95F42819DB7500E7678C /* XCRemoteSwiftPackageReference "conversations-ios" */,
 			);
 			productRefGroup = DC5F453626CC061A009C5C79 /* Products */;
 			projectDirPath = "";
@@ -718,6 +739,7 @@
 				DC6404D8271B68D4004730C6 /* ParticipantsViewModel.swift in Sources */,
 				DCB1BE0027568F5B006CE9D1 /* PasscodeComponents.swift in Sources */,
 				DC1ED0FD26E14D0B00FFA769 /* StreamToolbar.swift in Sources */,
+				DC0A96052819E2C600E7678C /* ChatMessage.swift in Sources */,
 				DC1ED0F926E1440200FFA769 /* StreamStatusView.swift in Sources */,
 				DC504A7726F1468E00C37EC9 /* SpeakerVideoView.swift in Sources */,
 				DC175F34270E3FD200D9D1FE /* SyncUsersMap.swift in Sources */,
@@ -753,6 +775,7 @@
 				DCCA727327B5C142006B0441 /* PresentationVideoView.swift in Sources */,
 				DCADF33727FC95DF0093A9FE /* GeneralSettingsView.swift in Sources */,
 				DC4AA65926D0133600E677D5 /* Color.swift in Sources */,
+				DC0A9607281B2F0F00E7678C /* ChatView.swift in Sources */,
 				DCCA726D27B5890E006B0441 /* SpeakerVideoViewModelFactory.swift in Sources */,
 				DC3BB82527445F9A005D0327 /* ParticipantsHeader.swift in Sources */,
 				DCC1D62826D9568700892038 /* StreamConfig.swift in Sources */,
@@ -762,6 +785,7 @@
 				DC6404D4271B3BF8004730C6 /* StreamViewModel.swift in Sources */,
 				DCB4497426F5496400B52774 /* SpeakerSettingsManager.swift in Sources */,
 				DC1ED0FB26E144AE00FFA769 /* StreamToolbarButton.swift in Sources */,
+				DC0A95F92819E1C800E7678C /* ChatManager.swift in Sources */,
 				DC5F453926CC061A009C5C79 /* LiveVideoApp.swift in Sources */,
 				DC175F37270E5B6F00D9D1FE /* ParticipantsView.swift in Sources */,
 				DC3BB82727480A9E005D0327 /* RemoveSpeakerRequest.swift in Sources */,
@@ -1120,6 +1144,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		DC0A95F42819DB7500E7678C /* XCRemoteSwiftPackageReference "conversations-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/twilio/conversations-ios";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.2.0;
+			};
+		};
 		DC175F2E270E238F00D9D1FE /* XCRemoteSwiftPackageReference "twilio-sync-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/twilio/twilio-sync-ios";
@@ -1179,6 +1211,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		DC0A95F52819DB7500E7678C /* TwilioConversationsClient */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DC0A95F42819DB7500E7678C /* XCRemoteSwiftPackageReference "conversations-ios" */;
+			productName = TwilioConversationsClient;
+		};
 		DC175F2F270E238F00D9D1FE /* TwilioSyncClient */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = DC175F2E270E238F00D9D1FE /* XCRemoteSwiftPackageReference "twilio-sync-ios" */;

--- a/apps/ios/LiveVideo/LiveVideo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/apps/ios/LiveVideo/LiveVideo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "TwilioConversationsClient",
+        "repositoryURL": "https://github.com/twilio/conversations-ios",
+        "state": {
+          "branch": null,
+          "revision": "df44d958cdc810d343b06e555107d1ab0f66b491",
+          "version": "2.2.2"
+        }
+      },
+      {
         "package": "CwlCatchException",
         "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
         "state": {

--- a/apps/ios/LiveVideo/LiveVideo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/apps/ios/LiveVideo/LiveVideo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/twilio/twilio-live-player-ios",
         "state": {
           "branch": null,
-          "revision": "7c4827e0bdb3b935aecdce9fa3c1b3c42ba60dd5",
-          "version": "1.0.1"
+          "revision": "97dff98041229cfe90c9d2e5b930c836279a9a48",
+          "version": "1.1.0"
         }
       },
       {

--- a/apps/ios/LiveVideo/LiveVideo/Launch/LiveVideoApp.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Launch/LiveVideoApp.swift
@@ -17,6 +17,7 @@ struct LiveVideoApp: App {
     @StateObject private var presentationLayoutViewModel = PresentationLayoutViewModel()
     @StateObject private var api = API()
     @StateObject private var appSettingsManager = AppSettingsManager()
+    @StateObject private var chatManager = ChatManager()
 
     var body: some Scene {
         WindowGroup {
@@ -31,6 +32,7 @@ struct LiveVideoApp: App {
                 .environmentObject(hostControlsManager)
                 .environmentObject(api)
                 .environmentObject(appSettingsManager)
+                .environmentObject(chatManager)
                 .onAppear {
                     authManager.configure(api: api, appSettingsManager: appSettingsManager)
                     let localParticipant = LocalParticipantManager(authManager: authManager)
@@ -48,12 +50,14 @@ struct LiveVideoApp: App {
                         userDocument: userDocument,
                         appSettingsManager: appSettingsManager
                     )
+                    chatManager.configure(appSettingsManager: appSettingsManager)
                     streamManager.configure(
                         roomManager: roomManager,
                         playerManager: PlayerManager(),
                         syncManager: syncManager,
                         api: api,
-                        appSettingsManager: appSettingsManager
+                        appSettingsManager: appSettingsManager,
+                        chatManager: chatManager
                     )
                     streamViewModel.configure(
                         streamManager: streamManager,

--- a/apps/ios/LiveVideo/LiveVideo/Twilio/Chat/ChatManager.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Twilio/Chat/ChatManager.swift
@@ -5,11 +5,15 @@
 import TwilioConversationsClient
 
 class ChatManager: NSObject, ObservableObject {
-    @Published var messages: [ChatMessage] = []
+    @Published private(set) var messages: [ChatMessage] = []
     private var client: TwilioConversationsClient?
     private var conversation: TCHConversation?
     private var conversationName = ""
     private var appSettingsManager: AppSettingsManager!
+
+    init(messages: [ChatMessage] = []) {
+        self.messages = messages
+    }
     
     func configure(appSettingsManager: AppSettingsManager) {
         self.appSettingsManager = appSettingsManager

--- a/apps/ios/LiveVideo/LiveVideo/Twilio/Chat/ChatManager.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Twilio/Chat/ChatManager.swift
@@ -1,0 +1,91 @@
+//
+//  Copyright (C) 2022 Twilio, Inc.
+//
+
+import Combine
+import TwilioConversationsClient
+
+class ChatManager: NSObject, ObservableObject {
+    @Published var messages: [ChatMessage] = []
+    private var client: TwilioConversationsClient?
+    private var conversation: TCHConversation?
+    private var conversationName = ""
+    private var appSettingsManager: AppSettingsManager!
+    
+    func configure(appSettingsManager: AppSettingsManager) {
+        self.appSettingsManager = appSettingsManager
+    }
+
+    func connect(accessToken: String, conversationName: String) {
+        self.conversationName = conversationName
+        
+        let properties = TwilioConversationsClientProperties()
+        
+        if let region = appSettingsManager.environment.region {
+            properties.region = region /// Only used by Twilio employees for internal testing
+        }
+        
+        TwilioConversationsClient.conversationsClient(
+            withToken: accessToken,
+            properties: properties,
+            delegate: self
+        ) { [weak self] _, client in
+            self?.client = client
+        }
+    }
+
+    func disconnect() {
+        client?.shutdown()
+        client = nil
+        conversation = nil
+        messages = []
+    }
+
+    func sendMessage(_ message: String) {
+        conversation?.prepareMessage().setBody(message).buildAndSend(completion: nil)
+    }
+
+    private func getConversation() {
+        client?.conversation(withSidOrUniqueName: conversationName) { [weak self] _, conversation in
+            self?.conversation = conversation
+            self?.getMessages()
+        }
+    }
+    
+    private func getMessages() {
+        /// Just get the last 100 messages since the UI does not have pagination in this app
+        conversation?.getLastMessages(withCount: 100) { [weak self] _, messages in
+            self?.messages = messages?.compactMap { ChatMessage(message: $0) } ?? []
+        }
+    }
+}
+
+extension ChatManager: TwilioConversationsClientDelegate {
+    func conversationsClient(
+        _ client: TwilioConversationsClient,
+        synchronizationStatusUpdated status: TCHClientSynchronizationStatus
+    ) {
+        switch status {
+        case .started, .conversationsListCompleted:
+            return
+        case .completed:
+            getConversation()
+        case .failed:
+            disconnect()
+        @unknown default:
+            return
+        }
+    }
+    
+    func conversationsClient(
+        _ client: TwilioConversationsClient,
+        conversation: TCHConversation,
+        messageAdded message: TCHMessage
+    ) {
+        guard conversation.sid == self.conversation?.sid, let message = ChatMessage(message: message) else {
+            return
+        }
+
+        messages.append(message)
+    }
+}

--- a/apps/ios/LiveVideo/LiveVideo/Twilio/Chat/ChatManager.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Twilio/Chat/ChatManager.swift
@@ -2,7 +2,6 @@
 //  Copyright (C) 2022 Twilio, Inc.
 //
 
-import Combine
 import TwilioConversationsClient
 
 class ChatManager: NSObject, ObservableObject {

--- a/apps/ios/LiveVideo/LiveVideo/Twilio/Chat/ChatMessage.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Twilio/Chat/ChatMessage.swift
@@ -5,17 +5,10 @@
 import TwilioConversationsClient
 
 struct ChatMessage: Identifiable {
-    var id: String
-    var author: String
-    var dateCreated: Date
-    var body: String
-    
-    init() {
-        id = UUID().uuidString
-        author = ""
-        dateCreated = Date()
-        body = ""
-    }
+    let id: String
+    let author: String
+    let dateCreated: Date
+    let body: String
 
     init?(message: TCHMessage) {
         guard

--- a/apps/ios/LiveVideo/LiveVideo/Twilio/Chat/ChatMessage.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Twilio/Chat/ChatMessage.swift
@@ -1,0 +1,35 @@
+//
+//  Copyright (C) 2022 Twilio, Inc.
+//
+
+import TwilioConversationsClient
+
+struct ChatMessage: Identifiable {
+    var id: String
+    var author: String
+    var dateCreated: Date
+    var body: String
+    
+    init() {
+        id = UUID().uuidString
+        author = ""
+        dateCreated = Date()
+        body = ""
+    }
+
+    init?(message: TCHMessage) {
+        guard
+            let sid = message.sid,
+            let dateCreated = message.dateCreatedAsDate,
+            let author = message.author,
+            let body = message.body
+        else {
+            return nil
+        }
+
+        id = sid
+        self.author = author
+        self.dateCreated = dateCreated
+        self.body = body
+    }
+}

--- a/apps/ios/LiveVideo/LiveVideo/Twilio/Chat/ChatView.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Twilio/Chat/ChatView.swift
@@ -25,6 +25,7 @@ struct ChatView: View {
 
                 HStack {
                     TextField("Write a message...", text: $messageText)
+                    
                     Button("Send") {
                         chatManager.sendMessage(messageText)
                         messageText = ""
@@ -53,9 +54,9 @@ struct ChatView_Previews: PreviewProvider {
 }
 
 extension ChatManager {
-    static func stub() -> ChatManager {
+    static func stub(messages: [ChatMessage] = [.stub()]) -> ChatManager {
         let chatManager = ChatManager()
-        chatManager.messages = Array(1...3).map { ChatMessage.stub(body: "Message \($0)") }
+        chatManager.messages = messages
         return chatManager
     }
 }

--- a/apps/ios/LiveVideo/LiveVideo/Twilio/Chat/ChatView.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Twilio/Chat/ChatView.swift
@@ -1,0 +1,70 @@
+//
+//  Copyright (C) 2022 Twilio, Inc.
+//
+
+import SwiftUI
+
+struct ChatView: View {
+    @EnvironmentObject var chatManager: ChatManager
+    @Environment(\.presentationMode) var presentationMode
+    @State private var messageText = ""
+
+    var body: some View {
+        NavigationView {
+            VStack {
+                List {
+                    ForEach(chatManager.messages) { message in
+                        VStack(alignment: .leading) {
+                            Text(message.body)
+                            Text(message.author)
+                            Text(message.dateCreated, style: .time)
+                        }
+                    }
+                }
+                .listStyle(.plain)
+
+                HStack {
+                    TextField("Write a message...", text: $messageText)
+                    Button("Send") {
+                        chatManager.sendMessage(messageText)
+                        messageText = ""
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("Chat")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        presentationMode.wrappedValue.dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct ChatView_Previews: PreviewProvider {
+    static var previews: some View {
+        ChatView()
+            .environmentObject(ChatManager.stub())
+    }
+}
+
+extension ChatManager {
+    static func stub() -> ChatManager {
+        let chatManager = ChatManager()
+        chatManager.messages = Array(1...3).map { ChatMessage.stub(body: "Message \($0)") }
+        return chatManager
+    }
+}
+
+extension ChatMessage {
+    static func stub(body: String = "Message", author: String = "Bob") -> ChatMessage {
+        var message = ChatMessage()
+        message.body = body
+        message.author = author
+        return message
+    }
+}

--- a/apps/ios/LiveVideo/LiveVideo/Twilio/Chat/ChatView.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Twilio/Chat/ChatView.swift
@@ -55,17 +55,24 @@ struct ChatView_Previews: PreviewProvider {
 
 extension ChatManager {
     static func stub(messages: [ChatMessage] = [.stub()]) -> ChatManager {
-        let chatManager = ChatManager()
-        chatManager.messages = messages
-        return chatManager
+        ChatManager(messages: messages)
     }
 }
 
 extension ChatMessage {
-    static func stub(body: String = "Message", author: String = "Bob") -> ChatMessage {
-        var message = ChatMessage()
-        message.body = body
-        message.author = author
-        return message
+    static func stub(
+        id: String = UUID().uuidString,
+        author: String = "Bob",
+        dateCreated: Date = Date(),
+        body: String = "Message"
+    ) -> ChatMessage {
+        ChatMessage(id: id, author: author, dateCreated: dateCreated, body: body)
+    }
+    
+    private init(id: String, author: String, dateCreated: Date, body: String) {
+        self.id = id
+        self.author = author
+        self.dateCreated = dateCreated
+        self.body = body
     }
 }

--- a/apps/ios/LiveVideo/LiveVideo/Twilio/Stream/StreamManager.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Twilio/Stream/StreamManager.swift
@@ -47,7 +47,7 @@ class StreamManager: ObservableObject {
         roomManager.roomConnectPublisher
             .sink { [weak self] in
                 self?.state = .connected
-                self?.connectChat()
+                self?.connectChat() /// Chat is not essential so connect it separately
             }
             .store(in: &subscriptions)
 

--- a/apps/ios/LiveVideo/LiveVideo/Twilio/Stream/StreamManager.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Twilio/Stream/StreamManager.swift
@@ -23,8 +23,10 @@ class StreamManager: ObservableObject {
     private var roomManager: RoomManager!
     private var playerManager: PlayerManager!
     private var syncManager: SyncManager!
+    private var chatManager: ChatManager!
     private var api: API!
     private var appSettingsManager: AppSettingsManager!
+    private var accessToken: String?
     private var subscriptions = Set<AnyCancellable>()
 
     func configure(
@@ -32,16 +34,21 @@ class StreamManager: ObservableObject {
         playerManager: PlayerManager,
         syncManager: SyncManager,
         api: API,
-        appSettingsManager: AppSettingsManager
+        appSettingsManager: AppSettingsManager,
+        chatManager: ChatManager
     ) {
         self.roomManager = roomManager
         self.playerManager = playerManager
         self.syncManager = syncManager
         self.api = api
         self.appSettingsManager = appSettingsManager
+        self.chatManager = chatManager
         
         roomManager.roomConnectPublisher
-            .sink { [weak self] in self?.state = .connected }
+            .sink { [weak self] in
+                self?.state = .connected
+                self?.connectChat()
+            }
             .store(in: &subscriptions)
 
         roomManager.roomDisconnectPublisher
@@ -80,6 +87,7 @@ class StreamManager: ObservableObject {
         roomManager.disconnect()
         playerManager.disconnect()
         syncManager.disconnect()
+        chatManager.disconnect()
         player = nil
         state = .disconnected
         
@@ -115,6 +123,8 @@ class StreamManager: ObservableObject {
         api.request(request) { [weak self] result in
             switch result {
             case let .success(response):
+                self?.accessToken = response.token
+                
                 let objectNames = SyncManager.ObjectNames(
                     speakersMap: response.syncObjectNames.speakersMap,
                     viewersMap: response.syncObjectNames.viewersMap,
@@ -152,6 +162,14 @@ class StreamManager: ObservableObject {
         case .viewer:
             playerManager.connect(accessToken: accessToken)
         }
+    }
+    
+    private func connectChat() {
+        guard let accessToken = accessToken, let roomSID = roomManager.roomSID else {
+            return
+        }
+        
+        chatManager.connect(accessToken: accessToken, conversationName: roomSID)
     }
     
     private func handleError(_ error: Error) {

--- a/apps/ios/LiveVideo/LiveVideo/Views/Stream/StreamToolbar.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Views/Stream/StreamToolbar.swift
@@ -12,7 +12,7 @@ struct StreamToolbar<Content>: View where Content: View {
     }
     
     var body: some View {
-        HStack(spacing: 10) {
+        HStack(spacing: 0) {
             Spacer()
             content()
             Spacer()

--- a/apps/ios/LiveVideo/LiveVideo/Views/Stream/StreamView.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Views/Stream/StreamView.swift
@@ -15,6 +15,7 @@ struct StreamView: View {
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
     @Environment(\.verticalSizeClass) var verticalSizeClass
     @State private var isShowingParticipants = false
+    @State private var isShowingChat = false
     private let app = UIApplication.shared
     private let spacing: CGFloat = 6
     
@@ -102,6 +103,12 @@ struct StreamView: View {
                             isShowingParticipants = true
                         }
 
+                        StreamToolbarButton(
+                            image: Image(systemName: "message")
+                        ) {
+                            isShowingChat = true
+                        }
+                        
                         if streamManager.config.role == .speaker {
                             Menu {
                                 Button("Move to Viewers") {
@@ -139,6 +146,9 @@ struct StreamView: View {
         }
         .sheet(isPresented: $isShowingParticipants) {
             ParticipantsView()
+        }
+        .sheet(isPresented: $isShowingChat) {
+            ChatView()
         }
         .alert(item: $viewModel.alertIdentifier) { alertIdentifier in
             switch alertIdentifier {


### PR DESCRIPTION
We are adding a chat feature to this app so that all users can text chat with each other during the stream.

This PR is focused on basic integration of the Twilio Conversations SDK which will be used for the chat feature. 

The chat UI that was added was just a placeholder so that the SDK could be tested. The placeholder UI will be replaced with a 3rd party chat UI framework most likely in the next PR. The main reason is I think there are a lot of edge cases to handle with the keyboard and also dynamic height text field.

Also updated the player SDK.

### Placeholder chat UI:

![Simulator Screen Shot - iPhone 13 Pro - 2022-04-29 at 14 42 56](https://user-images.githubusercontent.com/1930363/166067930-c66fe2a8-5693-498b-a0a4-ad3f5e17bdb3.png)