### PR TITLE
Make chat work for viewers

### DIFF
--- a/apps/ios/LiveVideo/LiveVideo/Managers/API/CreateOrJoinStreamRequest.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Managers/API/CreateOrJoinStreamRequest.swift
@@ -19,6 +19,7 @@ struct CreateOrJoinStreamRequest: APIRequest {
         }
         
         let token: String
+        let roomSid: String
         let syncObjectNames: SyncObjectNames
     }
 

--- a/apps/ios/LiveVideo/LiveVideo/Managers/API/CreateOrJoinStreamRequest.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Managers/API/CreateOrJoinStreamRequest.swift
@@ -20,6 +20,7 @@ struct CreateOrJoinStreamRequest: APIRequest {
         
         let token: String
         let roomSid: String
+        let chatEnabled: Bool
         let syncObjectNames: SyncObjectNames
     }
 

--- a/apps/ios/LiveVideo/LiveVideo/Twilio/Chat/ChatManager.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Twilio/Chat/ChatManager.swift
@@ -7,6 +7,7 @@ import TwilioConversationsClient
 class ChatManager: NSObject, ObservableObject {
     @Published var hasUnreadMessage = false
     @Published private(set) var messages: [ChatMessage] = []
+    var isConnected: Bool { client != nil }
     private var client: TwilioConversationsClient?
     private var conversation: TCHConversation?
     private var conversationName = ""

--- a/apps/ios/LiveVideo/LiveVideo/Twilio/Stream/StreamManager.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Twilio/Stream/StreamManager.swift
@@ -167,7 +167,7 @@ class StreamManager: ObservableObject {
     }
     
     private func connectChat() {
-        guard let accessToken = accessToken, let roomSID = roomSID else {
+        guard !chatManager.isConnected, let accessToken = accessToken, let roomSID = roomSID else {
             return
         }
         

--- a/apps/ios/LiveVideo/LiveVideo/Twilio/Stream/StreamManager.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Twilio/Stream/StreamManager.swift
@@ -19,6 +19,7 @@ class StreamManager: ObservableObject {
     let errorPublisher = PassthroughSubject<Error, Never>()
     @Published var state = State.disconnected
     @Published var player: Player?
+    @Published var isChatEnabled = true
     var config: StreamConfig!
     private var roomManager: RoomManager!
     private var playerManager: PlayerManager!
@@ -126,6 +127,7 @@ class StreamManager: ObservableObject {
             case let .success(response):
                 self?.accessToken = response.token
                 self?.roomSID = response.roomSid
+                self?.isChatEnabled = response.chatEnabled
                 
                 let objectNames = SyncManager.ObjectNames(
                     speakersMap: response.syncObjectNames.speakersMap,
@@ -167,7 +169,7 @@ class StreamManager: ObservableObject {
     }
     
     private func connectChat() {
-        guard !chatManager.isConnected, let accessToken = accessToken, let roomSID = roomSID else {
+        guard isChatEnabled, !chatManager.isConnected, let accessToken = accessToken, let roomSID = roomSID else {
             return
         }
         

--- a/apps/ios/LiveVideo/LiveVideo/Twilio/Stream/StreamManager.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Twilio/Stream/StreamManager.swift
@@ -27,6 +27,7 @@ class StreamManager: ObservableObject {
     private var api: API!
     private var appSettingsManager: AppSettingsManager!
     private var accessToken: String?
+    private var roomSID: String?
     private var subscriptions = Set<AnyCancellable>()
 
     func configure(
@@ -124,6 +125,7 @@ class StreamManager: ObservableObject {
             switch result {
             case let .success(response):
                 self?.accessToken = response.token
+                self?.roomSID = response.roomSid
                 
                 let objectNames = SyncManager.ObjectNames(
                     speakersMap: response.syncObjectNames.speakersMap,
@@ -165,7 +167,7 @@ class StreamManager: ObservableObject {
     }
     
     private func connectChat() {
-        guard let accessToken = accessToken, let roomSID = roomManager.roomSID else {
+        guard let accessToken = accessToken, let roomSID = roomSID else {
             return
         }
         
@@ -193,6 +195,8 @@ extension StreamManager: PlayerManagerDelegate {
                 self?.handleError(error)
             }
         }
+
+        connectChat() /// Chat is not essential so connect it separately
     }
     
     func playerManager(_ playerManager: PlayerManager, didDisconnectWithError error: Error) {

--- a/apps/ios/LiveVideo/LiveVideo/Views/Stream/StreamView.swift
+++ b/apps/ios/LiveVideo/LiveVideo/Views/Stream/StreamView.swift
@@ -104,11 +104,14 @@ struct StreamView: View {
                             isShowingParticipants = true
                         }
 
-                        StreamToolbarButton(
-                            image: Image(systemName: "message"),
-                            shouldShowBadge: chatManager.hasUnreadMessage
-                        ) {
-                            isShowingChat = true
+                        /// The chat feature can be disabled from the backend
+                        if streamManager.isChatEnabled {
+                            StreamToolbarButton(
+                                image: Image(systemName: "message"),
+                                shouldShowBadge: chatManager.hasUnreadMessage
+                            ) {
+                                isShowingChat = true
+                            }
                         }
                         
                         if streamManager.config.role == .speaker {


### PR DESCRIPTION
1. Get room SID from backend so that viewers not connected to the video room can connect to chat.
2. Get chat feature flag from backend so that chat can be turned off to reduce cost.
3. If chat is turned off, don't show the chat button in the UI and don't connect to chat SDK.