### PR TITLE
task/VIDEO-10785/ Refactor_RemoteStorage_to_parse_error_body_from_Interceptor

### DIFF
--- a/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/network/LiveVideoRequestInterceptor.kt
+++ b/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/network/LiveVideoRequestInterceptor.kt
@@ -1,14 +1,19 @@
 package com.twilio.livevideo.app.network
 
+import com.google.gson.Gson
 import com.twilio.livevideo.app.manager.AuthenticatorManager
 import com.twilio.livevideo.app.util.PasscodeUtil
 import okhttp3.HttpUrl
 import okhttp3.Interceptor
 import okhttp3.Response
+import okhttp3.ResponseBody
+import timber.log.Timber
 import javax.inject.Inject
 
 class LiveVideoRequestInterceptor @Inject constructor(private val authenticatorManager: AuthenticatorManager) :
     Interceptor {
+
+    private val gson = Gson()
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
@@ -31,7 +36,29 @@ class LiveVideoRequestInterceptor @Inject constructor(private val authenticatorM
 
             builder.url(newUrl)
         }
-        return chain.proceed(builder.build())
+        val response = chain.proceed(builder.build())
+
+        if (!response.isSuccessful) {
+            Timber.d("Response Not Successful")
+            response.apply {
+                var bodyString = peekBody(2048).string()
+                val contentType = this.body()?.contentType()
+                if (bodyString.isEmpty() || "not found".equals(bodyString, true)) {
+                    bodyString = "{\"error\":{\"message\":\"Error - ${response.code()}\",\"explanation\":\"${bodyString}\"}}"
+                }
+                val newResponseBody = ResponseBody.create(contentType, bodyString)
+
+                // Set response code to 299 to make the request pass as successful to allow OkHttp convert/parse automatically the error response.
+                // Otherwise, when there is an error code (<200 and >=300), Retrofit don't convert/parse the error response to allow
+                // the developer parse the error to any Model
+                return response.newBuilder()
+                    .code(299)
+                    .body(newResponseBody)
+                    .build()
+            }
+        }
+
+        return response
     }
 
     companion object {

--- a/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/repository/datasource/remote/RemoteStorage.kt
+++ b/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/repository/datasource/remote/RemoteStorage.kt
@@ -1,54 +1,42 @@
 package com.twilio.livevideo.app.repository.datasource.remote
 
-import com.google.gson.Gson
 import com.twilio.livevideo.app.repository.model.BaseResponse
 import com.twilio.livevideo.app.repository.model.CreateStreamResponse
 import com.twilio.livevideo.app.repository.model.DeleteStreamResponse
 import com.twilio.livevideo.app.repository.model.JoinStreamAsViewerResponse
 import com.twilio.livevideo.app.repository.model.VerifyPasscodeResponse
-import com.twilio.livevideo.app.util.ApiResponseUtil
 import retrofit2.Response
 import javax.inject.Inject
 
 class RemoteStorage @Inject constructor(private var liveVideoAPIService: LiveVideoAPIService) {
 
-    private val gson = Gson()
-
-    suspend fun verifyPasscode(passcode: String): VerifyPasscodeResponse =
-        processResponse(liveVideoAPIService.verifyPasscode(passcode))
+    suspend fun verifyPasscode(passcode: String): VerifyPasscodeResponse = liveVideoAPIService.verifyPasscode(passcode).let { response ->
+        (response.body() ?: VerifyPasscodeResponse()).also { setBaseResponse(it, response) }
+    }
 
     suspend fun joinStreamAsViewer(
         userIdentity: String,
         streamName: String
-    ): JoinStreamAsViewerResponse =
-        processResponse(liveVideoAPIService.joinStreamAsViewer(userIdentity, streamName))
+    ): JoinStreamAsViewerResponse = liveVideoAPIService.joinStreamAsViewer(userIdentity, streamName).let { response ->
+        (response.body() ?: JoinStreamAsViewerResponse()).also { setBaseResponse(it, response) }
+    }
 
     suspend fun createStream(
         userIdentity: String,
         streamName: String
-    ): CreateStreamResponse =
-        processResponse(liveVideoAPIService.createStream(userIdentity, streamName))
+    ): CreateStreamResponse = liveVideoAPIService.createStream(userIdentity, streamName).let { response ->
+        (response.body() ?: CreateStreamResponse()).also { setBaseResponse(it, response) }
+    }
 
     suspend fun deleteStream(
         streamName: String
-    ): DeleteStreamResponse =
-        processResponse(liveVideoAPIService.deleteStream(streamName))
+    ): DeleteStreamResponse = liveVideoAPIService.deleteStream(streamName).let { response ->
+        (response.body() ?: DeleteStreamResponse()).also { setBaseResponse(it, response) }
+    }
 
-    private inline fun <reified T : BaseResponse> processResponse(
-        response: Response<T>,
-    ): T {
-        val result: T = response.body() ?: T::class.java.newInstance()
+    private fun <T : BaseResponse> setBaseResponse(result: T, response: Response<T>) {
         result.code = response.code()
-        result.isApiResponseSuccess = response.errorBody() == null
-        if (!response.isSuccessful) { // Failure case
-            ApiResponseUtil.parseErrorBody(
-                gson,
-                response.errorBody(),
-                result,
-                T::class.java
-            )
-        }
-        return result
+        result.isApiResponseSuccess = response.code() != 299
     }
 
 }


### PR DESCRIPTION
## Pull Request Details

### JIRA link(s):
- [VIDEO-10785](https://issues.corp.twilio.com/browse/VIDEO-10785)

### Description

Refactor for RemoteStorage and LiveVideoRequestInterceptor in order to parse the error body from the interceptor.

However, all the parsing process to be moved to the `Interceptor` was not completely achieved, because `OkHttp` library that works underneath of `Retrofit` only allow internal parsing for Success responses, but not for Error responses. The reason behind of this, is to give the flexibility to `convert/parse` the error `json response` to any model class. 

So, the only way to achieve it was with a `Hack` changing the error `response code` to any success code (in this case: `299`) in the response from the interceptor. This, to pretend the internal parsing process to “simulate” the response was `Success` then validate it in the `RemoteStorage` class when the response has returned.

### But to be honest, I do not like this approach, I would prefer to keep using the current implementation, as we keep using the good/best recommended practices.

