### PR TITLE
task/VIDEO-11001 android transition move speaker as viewer

### DIFF
--- a/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/di/ComponentModule.kt
+++ b/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/di/ComponentModule.kt
@@ -1,6 +1,7 @@
 package com.twilio.livevideo.app.di
 
 import androidx.fragment.app.Fragment
+import com.twilio.livevideo.app.manager.GridManager
 import com.twilio.livevideo.app.manager.PlayerManager
 import com.twilio.livevideo.app.manager.permission.PermissionManager
 import com.twilio.livevideo.app.manager.room.LocalParticipantWrapper
@@ -26,5 +27,8 @@ class ComponentModule {
 
     @Provides
     fun provideLocalParticipantManager(fragment: Fragment): LocalParticipantWrapper = LocalParticipantWrapper(fragment.context)
+
+    @Provides
+    fun provideGridManager(): GridManager = GridManager()
 
 }

--- a/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/manager/room/LocalParticipantWrapper.kt
+++ b/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/manager/room/LocalParticipantWrapper.kt
@@ -40,10 +40,6 @@ data class LocalParticipantWrapper @Inject constructor(private val context: Cont
 
     private val localVideoTrackNames: MutableMap<String, String> = HashMap()
 
-    override fun onParticipantClick() {
-        //No OnClick event requirement for LocalParticipant.
-    }
-
     override fun init(lifecycle: Lifecycle) {
         super.init(lifecycle)
         setupLocalTracks()

--- a/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/manager/room/ParticipantStream.kt
+++ b/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/manager/room/ParticipantStream.kt
@@ -93,8 +93,6 @@ abstract class ParticipantStream : BaseLifeCycleComponent() {
             mIdentity.value = value?.identity
         }
 
-    abstract fun onParticipantClick()
-
     override fun onCreate(owner: LifecycleOwner) {
         Timber.i("onCreateCallback $identity")
     }

--- a/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/manager/room/RemoteParticipantWrapper.kt
+++ b/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/manager/room/RemoteParticipantWrapper.kt
@@ -12,8 +12,7 @@ import com.twilio.video.TwilioException
 import timber.log.Timber
 
 data class RemoteParticipantWrapper constructor(
-    private val remoteParticipantParam: RemoteParticipant?,
-    var clickCallback: ((RemoteParticipantWrapper) -> Unit)?
+    private val remoteParticipantParam: RemoteParticipant
 ) : ParticipantStream(), RemoteParticipant.Listener {
 
     var remoteParticipant: RemoteParticipant?
@@ -45,13 +44,8 @@ data class RemoteParticipantWrapper constructor(
         remoteParticipant = remoteParticipantParam
     }
 
-    override fun onParticipantClick() {
-        clickCallback?.invoke(this)
-    }
-
     override fun onDestroy(owner: LifecycleOwner) {
         Timber.d("onDestroy")
-        clickCallback = null
     }
 
     override fun onAudioTrackPublished(

--- a/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/manager/room/RoomManager.kt
+++ b/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/manager/room/RoomManager.kt
@@ -135,6 +135,7 @@ class RoomManager @Inject constructor(
             when (this) {
                 TwilioException.ROOM_ROOM_COMPLETED_EXCEPTION -> disconnect(RoomDisconnectionType.StreamEndedByHost)
                 TwilioException.PARTICIPANT_NOT_FOUND_EXCEPTION -> disconnect(RoomDisconnectionType.SpeakerMovedToViewersByHost)
+                else -> disconnect(RoomDisconnectionType.UnknownDisconnection(twilioException))
             }
         } ?: run {
             disconnect(RoomDisconnectionType.SpeakerMovedToViewersByHost)

--- a/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/manager/room/RoomManager.kt
+++ b/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/manager/room/RoomManager.kt
@@ -66,12 +66,13 @@ class RoomManager @Inject constructor(
     }
 
     fun disconnect() {
-        disconnect(null)
+        disconnect(null, false)
     }
 
-    private fun disconnect(disconnectionType: RoomDisconnectionType?) {
+    private fun disconnect(disconnectionType: RoomDisconnectionType?, notifyStateEvent: Boolean = true) {
         cleanUp()
-        _onStateEvent.value = RoomViewEvent.OnDisconnected(disconnectionType)
+        if (notifyStateEvent)
+            _onStateEvent.value = RoomViewEvent.OnDisconnected(disconnectionType)
     }
 
     private fun handleError(errorResponse: ErrorResponse?) {
@@ -86,10 +87,6 @@ class RoomManager @Inject constructor(
         room = null
     }
 
-    private fun remoteParticipantCallback(remoteParticipant: RemoteParticipantWrapper) {
-        _onStateEvent.value = RoomViewEvent.OnRemoteParticipantOnClickMenu(remoteParticipant)
-    }
-
     override fun onConnected(room: Room) {
         Timber.i("onConnected -> room sid: %s", room.sid)
 
@@ -101,7 +98,7 @@ class RoomManager @Inject constructor(
             room.remoteParticipants.filter {
                 !it.isVideoComposer()
             }.forEach {
-                val newRemoteParticipant = RemoteParticipantWrapper(it, ::remoteParticipantCallback)
+                val newRemoteParticipant = RemoteParticipantWrapper(it)
                 lifecycleOwner?.lifecycle?.apply { newRemoteParticipant.init(this) }
                 newRemoteParticipant.isLocalHost = localParticipantWrapper.isHost
                 list.add(newRemoteParticipant)
@@ -126,18 +123,28 @@ class RoomManager @Inject constructor(
     }
 
     override fun onDisconnected(room: Room, twilioException: TwilioException?) {
-        Timber.i("onDisconnected -> room sid: %s", room.sid)
+        Timber.i("onDisconnected -> room sid: ${room.sid}")
+        Timber.i("onDisconnected -> room exception message: ${twilioException?.message}")
+        Timber.i("onDisconnected -> room exception code: ${twilioException?.code}")
+        Timber.i("onDisconnected -> Lifecycle state: ${lifecycleOwner?.lifecycle?.currentState}")
+
+        // This condition is most when the room is disconnected by the local participant. In example, clicking the UI to disconnect the room.
+        if (this.room == null) return
+
         twilioException?.code?.apply {
-            if (this == TwilioException.ROOM_ROOM_COMPLETED_EXCEPTION) {
-                disconnect(RoomDisconnectionType.StreamEndedByHost)
+            when (this) {
+                TwilioException.ROOM_ROOM_COMPLETED_EXCEPTION -> disconnect(RoomDisconnectionType.StreamEndedByHost)
+                TwilioException.PARTICIPANT_NOT_FOUND_EXCEPTION -> disconnect(RoomDisconnectionType.SpeakerMovedToViewersByHost)
             }
+        } ?: run {
+            disconnect(RoomDisconnectionType.SpeakerMovedToViewersByHost)
         }
     }
 
     override fun onParticipantConnected(room: Room, remoteParticipant: RemoteParticipant) {
         Timber.i("onParticipantConnected -> room sid: %s", room.sid)
         if (remoteParticipant.isVideoComposer()) return
-        val newParticipant = RemoteParticipantWrapper(remoteParticipant, ::remoteParticipantCallback)
+        val newParticipant = RemoteParticipantWrapper(remoteParticipant)
         lifecycleOwner?.lifecycle?.apply { newParticipant.init(this) }
         newParticipant.isLocalHost = localParticipantWrapper.isHost
         _onStateEvent.value = RoomViewEvent.OnRemoteParticipantConnected(newParticipant)

--- a/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/manager/room/RoomViewEvent.kt
+++ b/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/manager/room/RoomViewEvent.kt
@@ -10,10 +10,10 @@ sealed class RoomViewEvent {
     data class OnDominantSpeakerChanged(val participantIdentity: String?) : RoomViewEvent()
     data class OnRemoteParticipantConnected(val participant: ParticipantStream) : RoomViewEvent()
     data class OnRemoteParticipantDisconnected(val participantIdentity: String) : RoomViewEvent()
-    data class OnRemoteParticipantOnClickMenu(val participant: RemoteParticipantWrapper) : RoomViewEvent()
 
 }
 
 sealed class RoomDisconnectionType {
     object StreamEndedByHost : RoomDisconnectionType()
+    object SpeakerMovedToViewersByHost : RoomDisconnectionType()
 }

--- a/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/manager/room/RoomViewEvent.kt
+++ b/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/manager/room/RoomViewEvent.kt
@@ -1,6 +1,7 @@
 package com.twilio.livevideo.app.manager.room
 
 import com.twilio.livevideo.app.repository.model.ErrorResponse
+import com.twilio.video.TwilioException
 
 sealed class RoomViewEvent {
 
@@ -16,4 +17,5 @@ sealed class RoomViewEvent {
 sealed class RoomDisconnectionType {
     object StreamEndedByHost : RoomDisconnectionType()
     object SpeakerMovedToViewersByHost : RoomDisconnectionType()
+    data class UnknownDisconnection(val twilioException: TwilioException) : RoomDisconnectionType()
 }

--- a/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/repository/LiveVideoRepository.kt
+++ b/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/repository/LiveVideoRepository.kt
@@ -6,6 +6,7 @@ import com.twilio.livevideo.app.repository.model.CreateStreamResponse
 import com.twilio.livevideo.app.repository.model.DeleteStreamResponse
 import com.twilio.livevideo.app.repository.model.JoinStreamAsSpeakerResponse
 import com.twilio.livevideo.app.repository.model.JoinStreamAsViewerResponse
+import com.twilio.livevideo.app.repository.model.RemoveSpeakerResponse
 import com.twilio.livevideo.app.repository.model.VerifyPasscodeResponse
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -49,6 +50,13 @@ class LiveVideoRepository @Inject constructor(
         streamName: String
     ): JoinStreamAsSpeakerResponse = withContext(dispatcher) {
         remoteStorage.joinStreamAsSpeaker(authenticator.getUserName(), streamName)
+    }
+
+    suspend fun removeSpeaker(
+        userIdentity: String,
+        roomName: String
+    ): RemoveSpeakerResponse = withContext(dispatcher) {
+        remoteStorage.removeSpeaker(userIdentity, roomName)
     }
 
 }

--- a/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/repository/datasource/remote/LiveVideoAPIService.kt
+++ b/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/repository/datasource/remote/LiveVideoAPIService.kt
@@ -5,6 +5,7 @@ import com.twilio.livevideo.app.repository.model.CreateStreamResponse
 import com.twilio.livevideo.app.repository.model.DeleteStreamResponse
 import com.twilio.livevideo.app.repository.model.JoinStreamAsSpeakerResponse
 import com.twilio.livevideo.app.repository.model.JoinStreamAsViewerResponse
+import com.twilio.livevideo.app.repository.model.RemoveSpeakerResponse
 import com.twilio.livevideo.app.repository.model.VerifyPasscodeResponse
 import retrofit2.Response
 import retrofit2.http.GET
@@ -38,4 +39,10 @@ interface LiveVideoAPIService {
         @Query("user_identity") userIdentity: String,
         @Query("stream_name") streamName: String
     ): Response<JoinStreamAsSpeakerResponse>
+
+    @GET("/remove-speaker")
+    suspend fun removeSpeaker(
+        @Query("user_identity") userIdentity: String,
+        @Query("room_name") roomName: String
+    ): Response<RemoveSpeakerResponse>
 }

--- a/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/repository/datasource/remote/RemoteStorage.kt
+++ b/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/repository/datasource/remote/RemoteStorage.kt
@@ -7,6 +7,7 @@ import com.twilio.livevideo.app.repository.model.DeleteStreamResponse
 import com.twilio.livevideo.app.repository.model.ErrorResponse
 import com.twilio.livevideo.app.repository.model.JoinStreamAsSpeakerResponse
 import com.twilio.livevideo.app.repository.model.JoinStreamAsViewerResponse
+import com.twilio.livevideo.app.repository.model.RemoveSpeakerResponse
 import com.twilio.livevideo.app.repository.model.VerifyPasscodeResponse
 import retrofit2.Response
 import retrofit2.Retrofit
@@ -40,6 +41,12 @@ class RemoteStorage @Inject constructor(private val liveVideoAPIService: LiveVid
         streamName: String
     ): JoinStreamAsSpeakerResponse =
         validateResponse(liveVideoAPIService.joinStreamAsSpeaker(userIdentity, streamName))
+
+    suspend fun removeSpeaker(
+        userIdentity: String,
+        roomName: String
+    ): RemoveSpeakerResponse =
+        validateResponse(liveVideoAPIService.removeSpeaker(userIdentity, roomName))
 
     private inline fun <reified T : BaseResponse> validateResponse(
         response: Response<T>,

--- a/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/repository/model/LiveVideoAPIResponses.kt
+++ b/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/repository/model/LiveVideoAPIResponses.kt
@@ -39,7 +39,7 @@ data class RaiseHandResponse(
 
 data class RemoveSpeakerResponse(
     @SerializedName("removed")
-    val isRemoved: Boolean
+    val isRemoved: Boolean = false
 ) : BaseResponse()
 
 data class SendSpeakerInviteResponse(

--- a/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/util/BindingAdapter.kt
+++ b/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/util/BindingAdapter.kt
@@ -2,13 +2,10 @@ package com.twilio.livevideo.app.util
 
 import android.view.View
 import android.view.ViewGroup
-import android.widget.GridLayout
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.databinding.BindingAdapter
 import com.twilio.livevideo.app.R
-import com.twilio.livevideo.app.manager.GridManager
-import com.twilio.livevideo.app.manager.room.ParticipantStream
 import com.twilio.video.VideoTextureView
 import com.twilio.video.VideoTrack
 import timber.log.Timber

--- a/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/view/StreamFragment.kt
+++ b/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/view/StreamFragment.kt
@@ -238,6 +238,7 @@ class StreamFragment internal constructor() : Fragment() {
                     when (event.disconnectionType) {
                         RoomDisconnectionType.StreamEndedByHost -> showDisconnectedRoomAlert()
                         RoomDisconnectionType.SpeakerMovedToViewersByHost -> createSpeakerMovedToViewersByHostDialog()
+                        is RoomDisconnectionType.UnknownDisconnection -> {}
                         null -> {}
                     }
                 }

--- a/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/viewmodel/StreamViewEvent.kt
+++ b/apps/android/LiveVideoApp/app/src/main/java/com/twilio/livevideo/app/viewmodel/StreamViewEvent.kt
@@ -8,4 +8,5 @@ sealed class StreamViewEvent {
     object OnDeleteStream : StreamViewEvent()
     data class OnStreamError(val error: ErrorResponse?) : StreamViewEvent()
     data class OnConnectSpeaker(val token: String) : StreamViewEvent()
+    data class OnSpeakerDisconnected(val identity: String) : StreamViewEvent()
 }

--- a/apps/android/LiveVideoApp/app/src/main/res/layout/fragment_stream.xml
+++ b/apps/android/LiveVideoApp/app/src/main/res/layout/fragment_stream.xml
@@ -28,8 +28,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
                 android:layout_weight="1"
-                app:layout_optimizationLevel="dimensions"
-                android:background="#121C2D">
+                android:background="#121C2D"
+                app:layout_optimizationLevel="dimensions">
 
                 <ImageView
                     android:id="@+id/stream_status"
@@ -85,14 +85,16 @@
                     app:layout_constraintHorizontal_bias="0"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/stream_status"
-                    app:layout_constraintVertical_bias="0" />
+                    app:layout_constraintVertical_bias="0"
+                    app:visibleOrGone="@{!viewModel.viewState.isViewerRole}" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/offScreenCounter"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content">
+                android:layout_height="wrap_content"
+                app:visibleOrGone="@{!viewModel.viewState.isViewerRole}">
 
                 <TextView
                     android:layout_width="match_parent"

--- a/apps/android/LiveVideoApp/app/src/main/res/layout/participant_view_item.xml
+++ b/apps/android/LiveVideoApp/app/src/main/res/layout/participant_view_item.xml
@@ -72,11 +72,11 @@
             app:visibleOrInvisible="@{!item.isMicOnLiveData}" />
 
         <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/participantMenu"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_margin="5dp"
             android:contentDescription="@null"
-            android:onClick="@{() -> item.onParticipantClick()}"
             android:padding="12dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/apps/android/LiveVideoApp/app/src/main/res/menu/speaker_menu.xml
+++ b/apps/android/LiveVideoApp/app/src/main/res/menu/speaker_menu.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item android:id="@+id/moveAsViewer"
+        android:title="@string/move_to_viewers" />
+
+</menu>

--- a/apps/android/LiveVideoApp/app/src/main/res/values/strings.xml
+++ b/apps/android/LiveVideoApp/app/src/main/res/values/strings.xml
@@ -25,6 +25,11 @@
     <string name="twilio_live_video_events">Twilio Live Video\nEvents</string>
     <string name="twilio_join_event_ended_title">Event is not longer available</string>
     <string name="twilio_join_event_ended_description">This event has been ended by the host.</string>
+    <string name="twilio_host_disconnect_stream_title">Are you sure?</string>
+    <string name="twilio_host_disconnect_stream_description">This will end the event for everyone.</string>
+    <string name="twilio_transition_moved_to_viewers_title">Moved to viewers</string>
+    <string name="twilio_transition_moved_to_viewers_description">You have been moved to viewers by the host.</string>
     <string name="camera_video_track">Camera Video Track</string>
     <string name="off_screen_count">+%d more</string>
+    <string name="move_to_viewers">Move to viewers</string>
 </resources>


### PR DESCRIPTION
## Pull Request Details

### JIRA link(s):
- [VIDEO-11001](https://issues.corp.twilio.com/browse/VIDEO-11001)

### Description
- Implemented transition Speaker to Viewer by themself
- Implemented transition Speaker to Viewer by host
- Implemented API call to removeSpeaker
- Implemented UI popup menu for speaker bottom controls
- Implemented UI popup menu for each remote participants to allow Host moves speakers as viewers.

## Demo
- ### Host sends speaker as viewer
https://user-images.githubusercontent.com/929504/186794212-edb65f14-9bc9-4c33-b720-8bebb22756bd.mp4

- ### Speaker is sent as viewer by host
https://user-images.githubusercontent.com/929504/186981625-849224f3-4ba7-4949-8109-bcc365f690f9.mp4

- ### Speaker choose the move as viewer by themselves 
https://user-images.githubusercontent.com/929504/186982486-72b26f21-e6f7-4cfe-878f-2340dbef616a.mp4










